### PR TITLE
Deprecate spack config section in favor of a software config section

### DIFF
--- a/etc/ramble/defaults/software.yaml
+++ b/etc/ramble/defaults/software.yaml
@@ -1,3 +1,3 @@
-spack:
+software:
   packages: {}
   environments: {}

--- a/examples/basic_expansion_config.yaml
+++ b/examples/basic_expansion_config.yaml
@@ -31,22 +31,22 @@ ramble:
   spack:
     packages:
       gcc9:
-        spack_spec: gcc@9.3.0 target=x86_64
+        pkg_spec: gcc@9.3.0 target=x86_64
         compiler_spec: gcc@9.3.0
       ompi412:
-        spack_spec: openmpi@4.1.2 +legacylaunchers +pmi +thread_multiple +cxx target=x86_64
+        pkg_spec: openmpi@4.1.2 +legacylaunchers +pmi +thread_multiple +cxx target=x86_64
         compiler: gcc9
       impi2021:
-        spack_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.11.0
         compiler: gcc9
       openfoam:
-        spack_spec: openfoam-org@7
+        pkg_spec: openfoam-org@7
         compiler: gcc9
       flex:
-        spack_spec: flex@2.6.4
+        pkg_spec: flex@2.6.4
         compiler: gcc9
       wrfv4:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc9
     environments:
       openfoam:

--- a/examples/basic_expansion_config.yaml
+++ b/examples/basic_expansion_config.yaml
@@ -28,7 +28,7 @@ ramble:
               variables:
                 n_ranks: '1'
                 n_nodes: '1'
-  spack:
+  software:
     packages:
       gcc9:
         pkg_spec: gcc@9.3.0 target=x86_64

--- a/examples/basic_gromacs_config.yaml
+++ b/examples/basic_gromacs_config.yaml
@@ -37,7 +37,7 @@ ramble:
                 n_threads: '1'
                 size: '0003'
                 type: 'rf'
-  spack:
+  software:
     packages:
       gcc9:
         pkg_spec: gcc@9.4.0 target=x86_64

--- a/examples/basic_gromacs_config.yaml
+++ b/examples/basic_gromacs_config.yaml
@@ -40,13 +40,13 @@ ramble:
   spack:
     packages:
       gcc9:
-        spack_spec: gcc@9.4.0 target=x86_64
+        pkg_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
       impi2021:
-        spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+        pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
         compiler: gcc9
       gromacs:
-        spack_spec: gromacs@2021.6
+        pkg_spec: gromacs@2021.6
         compiler: gcc9
     environments:
       gromacs:

--- a/examples/basic_hostname_config.yaml
+++ b/examples/basic_hostname_config.yaml
@@ -43,6 +43,6 @@ ramble:
                 n_ranks: '2'
                 n_nodes: '1'
                 processes_per_node: '16'
-  spack:
+  software:
     packages: {}
     environments: {}

--- a/examples/full_expansion_config.yaml
+++ b/examples/full_expansion_config.yaml
@@ -31,19 +31,19 @@ ramble:
   spack:
     packages:
       gcc9:
-        spack_spec: gcc@9.3.0 target=x86_64
+        pkg_spec: gcc@9.3.0 target=x86_64
         compiler_spec: gcc@9.3.0
       ompi412:
-        spack_spec: openmpi@4.1.2 +legacylaunchers +pmi +thread_multiple +cxx target=x86_64
+        pkg_spec: openmpi@4.1.2 +legacylaunchers +pmi +thread_multiple +cxx target=x86_64
         compiler: gcc9
       openfoam-skx:
-        spack_spec: openfoam-org@7 target=cascadelake
+        pkg_spec: openfoam-org@7 target=cascadelake
         compiler: gcc9
       openfoam-zen2:
-        spack_spec: openfoam-org@7 target=zen2
+        pkg_spec: openfoam-org@7 target=zen2
         compiler: gcc9
       flex:
-        spack_spec: flex@2.6.4
+        pkg_spec: flex@2.6.4
         compiler: gcc9
     environments:
       openfoam-skx:

--- a/examples/full_expansion_config.yaml
+++ b/examples/full_expansion_config.yaml
@@ -28,7 +28,7 @@ ramble:
                 #^-- (partition, processes_per_node, n_nodes) ->
                                 #(part1, 16, openfoam-skx, 2), (part1, 16, openfoam-skx, 4)
                                 #(part2, 32, openfoam-zen2, 2), (part2, 32, openfoam-zen2, 4)
-  spack:
+  software:
     packages:
       gcc9:
         pkg_spec: gcc@9.3.0 target=x86_64

--- a/examples/vector_gromacs_software_config.yaml
+++ b/examples/vector_gromacs_software_config.yaml
@@ -28,13 +28,13 @@ ramble:
   spack:
     packages:
       gcc9:
-        spack_spec: gcc@9.4.0 target=x86_64
+        pkg_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
       impi2021:
-        spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+        pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
         compiler: gcc9
       gromacs-{gromacs_version}:
-        spack_spec: gromacs@{gromacs_version}
+        pkg_spec: gromacs@{gromacs_version}
         compiler: gcc9
     environments:
       gromacs-{gromacs_version}:

--- a/examples/vector_gromacs_software_config.yaml
+++ b/examples/vector_gromacs_software_config.yaml
@@ -25,7 +25,7 @@ ramble:
               - type
               - n_ranks
               - gromacs_version
-  spack:
+  software:
     packages:
       gcc9:
         pkg_spec: gcc@9.4.0 target=x86_64

--- a/examples/vector_matrix_gromacs_config.yaml
+++ b/examples/vector_matrix_gromacs_config.yaml
@@ -22,7 +22,7 @@ ramble:
               - app_workloads
               - type
               - n_ranks
-  spack:
+  software:
     packages:
       gcc9:
         pkg_spec: gcc@9.4.0 target=x86_64

--- a/examples/vector_matrix_gromacs_config.yaml
+++ b/examples/vector_matrix_gromacs_config.yaml
@@ -25,13 +25,13 @@ ramble:
   spack:
     packages:
       gcc9:
-        spack_spec: gcc@9.4.0 target=x86_64
+        pkg_spec: gcc@9.4.0 target=x86_64
         compiler_spec: gcc@9.4.0
       impi2021:
-        spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+        pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
         compiler: gcc9
       gromacs:
-        spack_spec: gromacs@2021.6
+        pkg_spec: gromacs@2021.6
         compiler: gcc9
     environments:
       gromacs:

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -36,7 +36,7 @@ Currently, Ramble supports the following configuration sections:
 * :ref:`modifier_repos <modifier-repos-config>`
 * :ref:`modifiers <modifiers-config>`
 * :ref:`repos <repos-config>`
-* :ref:`spack <spack-config>`
+* :ref:`software <software-config>`
 * :ref:`success_criteria <success-criteria-config>`
 * :ref:`variables <variables-config>`
 
@@ -464,18 +464,18 @@ be searched for when looking for application definitions. Its format is as follo
     - 'path/to/repo'
 
 
-.. _spack-config:
+.. _software-config:
 
 --------------
-Spack Section:
+Software Section:
 --------------
 
-The spack config section is used to define package definitions, and software
+The software config section is used to define package definitions, and software
 environments created from those packages. Its format is as follows:
 
 .. code-block:: yaml
 
-    spack:
+    software:
       [variables: {}]
       packages:
         <package_name>:
@@ -497,26 +497,27 @@ environments created from those packages. Its format is as follows:
         <external_env_name>:
           external_spack_env: 'name_or_path_to_spack_env'
 
-The packages dictionary houses ramble descriptions of spack packages that can
-be used to construct environments with. A package is defined as software that
-spack should install for the user. These have one required attribute, and two
-optional attributes. The ``pkg_spec`` attribute is required to be defined,
-and should be the spec passed to ``spack install`` on the command line for the
-package. Optionally, a package can define a ``compiler_spec`` attribute, which
-will be the spec used when this package is used as a compiler for another
-package. Packages can also optionally define a ``compiler`` attribute, which
-is the name of another package that should be used as it's compiler.
+The packages dictionary houses ramble descriptions of software packages that
+can be used to construct environments with. A package is defined as software
+that the defined package manager should install for the user. These have one
+required attribute, and two optional attributes. The ``pkg_spec`` attribute is
+required to be defined, and should be the arguments passed to the package
+manager's ``install`` subcommand. Optionally, a package can define a
+``compiler_spec`` attribute, which will be the spec used when this package is
+used as a compiler for another package. Packages can also optionally define a
+``compiler`` attribute, which is the name of another package that should be
+used as it's compiler.
 
-The environments dictionary contains descriptions of spack environments that
+The environments dictionary contains descriptions of groups of packages that
 Ramble might generate based on the requested experiments. Environments are
 defined as a list of packages (in the aforementioned packages dictionary) that
-should be bundled into a spack environment.
+should be bundled into a shared environment within the package manager.
 
-Below is an annotated example of the spack dictionary.
+Below is an annotated example of the software dictionary.
 
 .. code-block:: yaml
 
-    spack:
+    software:
       packages:
         gcc9: # Abstract name to refer to this package
           pkg_spec: gcc@9.3.0 target=x86_64 # Spack spec for this package
@@ -533,9 +534,21 @@ Below is an annotated example of the spack dictionary.
           - impi2021
           - gromacs
 
-Packages and environments defined inside the ``spack`` config section are
+Packages and environments defined inside the ``software`` config section are
 merely templates. They will be rendered into explicit environments and packages
 by each individual experiment.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Package Manager Specific Packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When selecting package managers within Ramble experiments, the default spec a
+package manager will use is contained in the ``pkg_spec`` attribute. If
+multiple package managers will use the same package definition, specs for each
+can be defined using the ``<package_manager>_pkg_spec`` syntax. This syntax can
+be used on the ``compiler`` and ``compiler_spec`` attributes as well, if the
+package manager supports selecting a specific compiler.
+
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 External Spack Environment Support:
@@ -552,7 +565,7 @@ This section shows how this feature can be used.
 
 .. code-block:: yaml
 
-    spack:
+    software:
       environments:
         gromacs:
           external_spack_env: name_or_path_to_spack_env

--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -479,8 +479,8 @@ environments created from those packages. Its format is as follows:
       [variables: {}]
       packages:
         <package_name>:
-          spack_spec: 'spack_spec_for_package'
-          compiler_spec: 'Compiler spec, if different from spack_spec' # Default: None
+          pkg_spec: 'pkg_spec_for_package'
+          compiler_spec: 'Compiler spec, if different from pkg_spec' # Default: None
           compiler: 'package_name_to_use_as_compiler' # Default: None
           [variables: {}]
           [matrix:]
@@ -500,7 +500,7 @@ environments created from those packages. Its format is as follows:
 The packages dictionary houses ramble descriptions of spack packages that can
 be used to construct environments with. A package is defined as software that
 spack should install for the user. These have one required attribute, and two
-optional attributes. The ``spack_spec`` attribute is required to be defined,
+optional attributes. The ``pkg_spec`` attribute is required to be defined,
 and should be the spec passed to ``spack install`` on the command line for the
 package. Optionally, a package can define a ``compiler_spec`` attribute, which
 will be the spec used when this package is used as a compiler for another
@@ -519,13 +519,13 @@ Below is an annotated example of the spack dictionary.
     spack:
       packages:
         gcc9: # Abstract name to refer to this package
-          spack_spec: gcc@9.3.0 target=x86_64 # Spack spec for this package
+          pkg_spec: gcc@9.3.0 target=x86_64 # Spack spec for this package
           compiler_spec: gcc@9.3.0 # Spack compiler spec for this package
         impi2021:
-          spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+          pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
           compiler: gcc9 # Other package name to use as compiler for this package
         gromacs:
-          spack_spec: gromacs@2022.4
+          pkg_spec: gromacs@2022.4
           compiler: gcc9
       environments:
         gromacs:

--- a/lib/ramble/docs/tutorials/10_using_modifiers.rst
+++ b/lib/ramble/docs/tutorials/10_using_modifiers.rst
@@ -146,12 +146,12 @@ The resulting configuration file should look like the following.
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -240,12 +240,12 @@ look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -309,14 +309,14 @@ configuration file should look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           aps:
-            spack_spec: intel-oneapi-vtune
+            pkg_spec: intel-oneapi-vtune
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:

--- a/lib/ramble/docs/tutorials/10_using_modifiers.rst
+++ b/lib/ramble/docs/tutorials/10_using_modifiers.rst
@@ -143,7 +143,7 @@ The resulting configuration file should look like the following.
                 scaling_{n_nodes}:
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -237,7 +237,7 @@ look like the following:
                 scaling_{n_nodes}:
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -306,7 +306,7 @@ configuration file should look like the following:
                 scaling_{n_nodes}:
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/11_using_internals.rst
+++ b/lib/ramble/docs/tutorials/11_using_internals.rst
@@ -140,12 +140,12 @@ the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -246,12 +246,12 @@ configuration file should look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -337,12 +337,12 @@ following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:

--- a/lib/ramble/docs/tutorials/11_using_internals.rst
+++ b/lib/ramble/docs/tutorials/11_using_internals.rst
@@ -137,7 +137,7 @@ the following:
                         use_mpi: false
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -243,7 +243,7 @@ configuration file should look like the following:
                     - end_time
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -334,7 +334,7 @@ following:
                       relative_to: execute
                   variables:
                     n_nodes: [1, 2, 4]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/1_hello_world.rst
+++ b/lib/ramble/docs/tutorials/1_hello_world.rst
@@ -21,7 +21,7 @@ Installation
 
 To install Ramble, see the :doc:`../getting_started` guide.
 
-**NOTE**: This tutorial does not require ``spack`` to be installed or configured.
+**NOTE**: This tutorial does not require a package manager to be installed or configured.
 
 Ramble Basics
 =============
@@ -175,11 +175,11 @@ following contents:
                 test: # Arbitrary experiment name
                   variables:
                     n_ranks: '1'
-      spack:
+      software:
         packages: {}
         environments: {}
 
-Note that since the ``hostname`` application does not rely on spack, the spack
+Note that since the ``hostname`` application does not rely on a package manager, the software
 dictionary has empty ``packages`` and ``environments`` dictionaries.
 
 The second file you should edit is the ``execute_experiment.tpl`` template file.
@@ -198,7 +198,7 @@ in the active workspace using:
     $ ramble workspace setup
 
 This command will create experiment directories, download and expand input files,
-and install the required software stack (and generate spack environments for
+and install the required software stack (and generate software environments for
 each workload).
 
 It can take a bit to run depending on if you need to build new software and how

--- a/lib/ramble/docs/tutorials/2_running_a_simple_gromacs_experiment.rst
+++ b/lib/ramble/docs/tutorials/2_running_a_simple_gromacs_experiment.rst
@@ -83,13 +83,13 @@ software configuration:
 
    Default Compilers:
     gcc9:
-      spack_spec = gcc@9.3.0
+      pkg_spec = gcc@9.3.0
 
     Software Specs:
       impi2021:
-        spack_spec = intel-oneapi-mpi@2021.11.0
+        pkg_spec = intel-oneapi-mpi@2021.11.0
       gromacs:
-        spack_spec = gromacs@2020.5
+        pkg_spec = gromacs@2020.5
         compiler = gcc9
 
 This output does not represent the only possible configuration that works for

--- a/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
+++ b/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
@@ -79,7 +79,7 @@ The relevant portion of the workspace configuration file is:
 
 .. code-block:: YAML
 
-    spack:
+    software:
       packages:
         gcc9:
           pkg_spec: gcc@9.4.0 target=x86_64
@@ -105,7 +105,7 @@ Each environment has a ``packages`` block, which contains a list of package
 names that are defined in the higher level ``packages`` block.
 
 These are further documented in the
-:ref:`Spack configuration section<spack-config>` documentation.
+:ref:`Software configuration section<software-config>` documentation.
 
 Changing Software Definitions
 -----------------------------

--- a/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
+++ b/lib/ramble/docs/tutorials/5_changing_your_software_stack.rst
@@ -82,13 +82,13 @@ The relevant portion of the workspace configuration file is:
     spack:
       packages:
         gcc9:
-          spack_spec: gcc@9.4.0 target=x86_64
+          pkg_spec: gcc@9.4.0 target=x86_64
           compiler_spec: gcc@9.4.0
         impi2021:
-          spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+          pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
           compiler: gcc9
         gromacs:
-          spack_spec: gromacs@2021.6
+          pkg_spec: gromacs@2021.6
           compiler: gcc9
       environments:
         gromacs:
@@ -170,10 +170,10 @@ Adding Package Variants
 
 So far, we have only explored changing the version a package used. More
 complicated changes to the Spack specs can be made by adding variant
-definitions. This can be directly added to the ``spack_spec`` lines within the
+definitions. This can be directly added to the ``pkg_spec`` lines within the
 package definitions in a workspace's ``ramble.yaml``.
 
-The ``spack_spec`` attribute can be parameterized with variable definitions
+The ``pkg_spec`` attribute can be parameterized with variable definitions
 also, to allow a wide range of variants to be explored with a single
 configuration.
 

--- a/lib/ramble/docs/tutorials/6_configuring_a_scaling_study.rst
+++ b/lib/ramble/docs/tutorials/6_configuring_a_scaling_study.rst
@@ -225,12 +225,12 @@ look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:

--- a/lib/ramble/docs/tutorials/6_configuring_a_scaling_study.rst
+++ b/lib/ramble/docs/tutorials/6_configuring_a_scaling_study.rst
@@ -199,7 +199,7 @@ suggested starting place for the experiments. To apply this to your workspace, u
 
     $ ramble workspace concretize
 
-This will fill out the ``spack`` dictionary within your workspace configuration
+This will fill out the ``software`` dictionary within your workspace configuration
 file. After executing this command, your workspace configuration file might
 look like the following:
 
@@ -222,7 +222,7 @@ look like the following:
                 scaling_{n_nodes}:
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/7_using_zips_and_matrices.rst
+++ b/lib/ramble/docs/tutorials/7_using_zips_and_matrices.rst
@@ -111,7 +111,7 @@ the above section. The result should look like the following:
                 scaling_{n_nodes}:
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -201,7 +201,7 @@ should have the following in your ``ramble.yaml``:
                   matrix:
                   - platform_config
                   - n_nodes
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -263,7 +263,7 @@ Your final configuration file should look something like:
                   matrix:
                   - platform_config
                   - n_nodes
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/7_using_zips_and_matrices.rst
+++ b/lib/ramble/docs/tutorials/7_using_zips_and_matrices.rst
@@ -114,12 +114,12 @@ the above section. The result should look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -204,12 +204,12 @@ should have the following in your ``ramble.yaml``:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -266,12 +266,12 @@ Your final configuration file should look something like:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:

--- a/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
+++ b/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
@@ -94,7 +94,7 @@ final configuration from the previous tutorial.
                   matrix:
                   - platform_config
                   - n_nodes
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -123,9 +123,9 @@ Define Additional MPI and Parameterize Software Environments
 
 To begin with, you will parameterize the software stack definitions to generate
 experiments using both IntelMPI and OpenMPI. For this section, you can focus on
-the ``spack`` portion of the ``ramble.yaml`` configuration file. For more
-information on how this section is constructed, see the :ref:`Spack config
-section<spack-config>` documentation.
+the ``software`` portion of the ``ramble.yaml`` configuration file. For more
+information on how this section is constructed, see the :ref:`Software config
+section<software-config>` documentation.
 
 To start with, you will create an OpenMPI package definition. This might look
 like the following:
@@ -138,8 +138,8 @@ like the following:
 
 In the definition of the Intel MPI package above, you'll see we originally
 specified a ``compiler`` attribute (with the value of ``gcc9``). This can be
-explicitly selected if you like, however Ramble generates Spack environments
-with ``unify: true``
+explicitly selected if you like, however when using Spack, Ramble generates
+Spack environments with ``unify: true``
 (See `Spack's environment documentation <https://spack.readthedocs.io/en/latest/environments.html#spec-concretization>`_
 for more details). As a result, OpenMPI should be compiled with the same
 compiler used for WRF.
@@ -190,7 +190,7 @@ generation as well. The result might look like the following:
                   matrix:
                   - platform_config
                   - n_nodes
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -260,7 +260,7 @@ into the matrix. The result might look like the following:
                   - platform_config
                   - n_nodes
                   - mpi_name
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -369,7 +369,7 @@ resulting configuration might look like the following:
                   - platform_config
                   - n_nodes
                   - mpi_name
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -458,7 +458,7 @@ The resulting configuration file might look like the following:
                   - platform_config
                   - n_nodes
                   - mpi_name
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
+++ b/lib/ramble/docs/tutorials/8_var_expansion_indirection_and_stack_parameterization.rst
@@ -97,12 +97,12 @@ final configuration from the previous tutorial.
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -134,7 +134,7 @@ like the following:
 
     packages:
       openmpi:
-        spack_spec: openmpi@3.1.6 +orterunprefix
+        pkg_spec: openmpi@3.1.6 +orterunprefix
 
 In the definition of the Intel MPI package above, you'll see we originally
 specified a ``compiler`` attribute (with the value of ``gcc9``). This can be
@@ -193,14 +193,14 @@ generation as well. The result might look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           openmpi:
-            spack_spec: openmpi@3.1.6 +orterunprefix
+            pkg_spec: openmpi@3.1.6 +orterunprefix
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -263,14 +263,14 @@ into the matrix. The result might look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           openmpi:
-            spack_spec: openmpi@3.1.6 +orterunprefix
+            pkg_spec: openmpi@3.1.6 +orterunprefix
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -372,14 +372,14 @@ resulting configuration might look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           openmpi:
-            spack_spec: openmpi@3.1.6 +orterunprefix
+            pkg_spec: openmpi@3.1.6 +orterunprefix
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -461,14 +461,14 @@ The resulting configuration file might look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           openmpi:
-            spack_spec: openmpi@3.1.6 +orterunprefix
+            pkg_spec: openmpi@3.1.6 +orterunprefix
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:

--- a/lib/ramble/docs/tutorials/9_success_criteria.rst
+++ b/lib/ramble/docs/tutorials/9_success_criteria.rst
@@ -119,7 +119,7 @@ configuration file might look like the following:
                 scaling_{n_nodes}:
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0
@@ -193,7 +193,7 @@ resulting configuration file might look like the following:
                 scaling_{n_nodes}:
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0

--- a/lib/ramble/docs/tutorials/9_success_criteria.rst
+++ b/lib/ramble/docs/tutorials/9_success_criteria.rst
@@ -122,12 +122,12 @@ configuration file might look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:
@@ -196,12 +196,12 @@ resulting configuration file might look like the following:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:

--- a/lib/ramble/docs/tutorials/mirrors.rst
+++ b/lib/ramble/docs/tutorials/mirrors.rst
@@ -64,11 +64,11 @@ Write the following configuration into the file, save, and exit:
                   variables:
                     n_nodes: 1
                     processes_per_node: 30
-      spack:
+      software:
         packages: {}
         environments: {}
 
-Run ``ramble workspace concretize`` to fill in the spack section. The result
+Run ``ramble workspace concretize`` to fill in the software section. The result
 will look something like this:
 
 .. code-block:: yaml
@@ -92,7 +92,7 @@ will look something like this:
                   variables:
                     n_nodes: 1
                     processes_per_node: 30
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.3.0
@@ -124,7 +124,7 @@ this mirror in the first place.
     $ ramble workspace mirror -d $HOME/wrfv4_mirror
 
     ==>     Executing phase mirror_inputs
-    ==>     Executing phase create_spack_env
+    ==>     Executing phase software_create_env
     ==> Concretized intel-oneapi-mpi@2021.11.0%gcc@<gcc-version>
      -   <hash>   intel-oneapi-mpi@2021.11.0%gcc@<version>_etc.
      -   <etc>        ^(short list of software prerequisistes for intel-mpi)
@@ -134,7 +134,7 @@ this mirror in the first place.
 
     ==>     Executing phase mirror_software
     ==>     Executing phase mirror_inputs
-    ==>     Executing phase create_spack_env
+    ==>     Executing phase software_create_env
     ==> Created environment in <workspace_dirs path>/wrfv4_mirror_test/software/wrfv4.CONUS_12km
     ==> You can activate this environment with:
     ==>   spack env activate <workspace_dirs path>/wrfv4_mirror_test/software/wrfv4.CONUS_12km

--- a/lib/ramble/docs/tutorials/mirrors.rst
+++ b/lib/ramble/docs/tutorials/mirrors.rst
@@ -95,12 +95,12 @@ will look something like this:
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.3.0
+            pkg_spec: gcc@9.3.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:

--- a/lib/ramble/docs/tutorials/shared/wrf_scaling_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/wrf_scaling_workspace.rst
@@ -47,12 +47,12 @@ final configuration from a previous tutorial.
       spack:
         packages:
           gcc9:
-            spack_spec: gcc@9.4.0
+            pkg_spec: gcc@9.4.0
           intel-mpi:
-            spack_spec: intel-oneapi-mpi@2021.11.0
+            pkg_spec: intel-oneapi-mpi@2021.11.0
             compiler: gcc9
           wrfv4:
-            spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
+            pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem
               ~pnetcdf
             compiler: gcc9
         environments:

--- a/lib/ramble/docs/tutorials/shared/wrf_scaling_workspace.rst
+++ b/lib/ramble/docs/tutorials/shared/wrf_scaling_workspace.rst
@@ -44,7 +44,7 @@ final configuration from a previous tutorial.
                 scaling_{n_nodes}:
                   variables:
                     n_nodes: [1, 2]
-      spack:
+      software:
         packages:
           gcc9:
             pkg_spec: gcc@9.4.0

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -17,17 +17,14 @@ workspace has a configuration file stored at ``$workspace/configs/ramble.yaml``.
 
 This document will describe the syntax for writing a workspace configuration file.
 
-Within the ``ramble.yaml`` file, there are two top level dictionairies.
+Within the ``ramble.yaml`` file, all content lives under the top level ``ramble`` dictionary:
 
 .. code-block:: console
 
    ramble:
      ...
-   spack:
-     ...
 
-Each of these dictionaries is used to control different aspects of the Ramble
-workspace.
+This dictionary is used to control all of the aspects of the Ramble workspace.
 
 -----------------
 Ramble Dictionary
@@ -875,7 +872,7 @@ Ramble automatically generates definitions for the following variables:
 * ``workload_name`` - Set to the name of the workload within the application
 * ``experiment_name`` - Set to the name of the experiment
 * ``env_name`` - By default defined as ``{application_name}``. Can be
-  overridden to control the spack definition to use.
+  overridden to control the software environment to use.
 * ``application_run_dir`` - Absolute path to
   ``$workspace_root/experiments/{application_name}``
 * ``workload_run_dir`` - Absolute path to
@@ -911,14 +908,14 @@ When using spack applications, Ramble also generates the following variables:
 * ``<software_spec_name>`` - Set to the equivalent of ``spack location -i
   <spec>`` for packages defined in a ramble ``spec_name`` package set.
   ``<software_spec_name>`` is set to the name of the package as defined in the
-  ``spack:packages`` dictionary.
+  ``software:packages`` dictionary.
 
 As an example:
 
 .. code-block:: yaml
 
     ramble:
-      spack:
+      software:
         packages:
           grm:
             pkg_spec: gromacs@2023.1
@@ -939,24 +936,24 @@ actually performing the setup of a workspace. When a ``--dry-run`` is
 performed, these paths are not populated.
 
 
-----------------
-Spack Dictionary
-----------------
+-------------------
+Software Dictionary
+-------------------
 
-Within a ramble.yaml file, the ``spack:`` dictionary controls the software
+Within a ramble.yaml file, the ``software:`` dictionary controls the software
 stack installation that ramble performs. This configuration section is defined
-in the :ref:`Spack section<spack-config>` documentation.
+in the :ref:`Software section<software-config>` documentation.
 a packages dictionary, and an environments dictionary.
 
 The ``ramble workspace concretize`` command can help construct a functional
-spack dictionary based on the experiments listed.
+software dictionary based on the experiments listed.
 
 It is important to note that packages and environments that are not used by an
 experiment are not installed.
 
 Application definition files can define one or more ``software_spec``
 directives, which are packages the application might need to run properly.
-Additionally, spack packages can be marked as required through the
+Additionally, packages can be marked as required through the
 ``required_package`` directive.
 
 -------------------------------------------
@@ -1002,7 +999,7 @@ Below is an example of running a Gromacs experiment in both MPICH and OpenMPI:
                     n_ranks: '1'
                     n_nodes: '1'
                     env_name: ['gromacs-mpich', 'gromacs-ompi']
-    spack:
+    software:
       packages:
         gcc9:
           pkg_spec: gcc@9.3.0 target=x86_64
@@ -1065,7 +1062,7 @@ variable can be used to submit the same experiment to multiple batch systems.
                   variables:
                     n_ranks: '1'
                     n_nodes: '1'
-    spack:
+    software:
       packages:
         gcc9:
           pkg_spec: gcc@9.3.0 target=x86_64

--- a/lib/ramble/docs/workspace_config.rst
+++ b/lib/ramble/docs/workspace_config.rst
@@ -921,7 +921,7 @@ As an example:
       spack:
         packages:
           grm:
-            spack_spec: gromacs@2023.1
+            pkg_spec: gromacs@2023.1
         environments:
           grm_env:
             packages:
@@ -930,7 +930,7 @@ As an example:
 Defines a software environment named ``grm_env``. The default environment used
 has the same name as the application the experiment is generated from. In
 experiments which use this ``grm_env`` environment, a variable is defined
-named: ``gromacs``, as that is the package named defined by the ``spack_spec``
+named: ``gromacs``, as that is the package named defined by the ``pkg_spec``
 attribute of the ``grm`` package definition. This variable contains the path to
 the installation location for the ``gromacs`` package.
 
@@ -1005,15 +1005,15 @@ Below is an example of running a Gromacs experiment in both MPICH and OpenMPI:
     spack:
       packages:
         gcc9:
-          spack_spec: gcc@9.3.0 target=x86_64
+          pkg_spec: gcc@9.3.0 target=x86_64
         mpich:
-          spack_spec: mpich@4.0.2 target=x86_64
+          pkg_spec: mpich@4.0.2 target=x86_64
           compiler: gcc9
         ompi:
-          spack_spec: openmpi@4.1.4 target=x86_64
+          pkg_spec: openmpi@4.1.4 target=x86_64
           compiler: gcc9
         gromacs:
-          spack_spec: gromacs@2022.4
+          pkg_spec: gromacs@2022.4
           compiler: gcc9
       environments:
         gromacs-{mpi}:
@@ -1068,12 +1068,12 @@ variable can be used to submit the same experiment to multiple batch systems.
     spack:
       packages:
         gcc9:
-          spack_spec: gcc@9.3.0 target=x86_64
+          pkg_spec: gcc@9.3.0 target=x86_64
         impi2021:
-          spack_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
+          pkg_spec: intel-oneapi-mpi@2021.11.0 target=x86_64
           compiler: gcc9
         gromacs:
-          spack_spec: gromacs@2022.4
+          pkg_spec: gromacs@2022.4
           compiler: gcc9
       environments:
         gromacs:

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -309,12 +309,10 @@ class SpackApplication(ApplicationBase):
 
         As an example:
         <ramble.yaml>
-        spack:
-          applications:
-            wrfv4:
-              wrf:
-                base: wrf
-                version: 4.2.2
+        software:
+          packages:
+            wrf:
+              pkg_spec: wrf@4.2.2
 
         Would define a variable `wrf` that contains the installation path of
         wrf@4.2.2

--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -45,7 +45,7 @@ class SpackApplication(ApplicationBase):
     _spec_groups = [('compilers', 'Compilers'),
                     ('mpi_libraries', 'MPI Libraries'),
                     ('software_specs', 'Software Specs')]
-    _spec_keys = ['spack_spec', 'compiler_spec', 'compiler']
+    _spec_keys = ['pkg_spec', 'compiler_spec', 'compiler']
 
     register_phase('make_experiments', pipeline='setup',
                    run_after=['define_package_paths'])

--- a/lib/ramble/ramble/cmd/software_definitions.py
+++ b/lib/ramble/ramble/cmd/software_definitions.py
@@ -25,11 +25,11 @@ definitions = {}
 conflicts = {}
 used_by = {}
 specs = {
-    'spack_spec': {},
+    'pkg_spec': {},
     'compiler_spec': {}
 }
 spec_headers = {
-    'spack_spec': 'Software Packages',
+    'pkg_spec': 'Software Packages',
     'compiler_spec': 'Compiler Definitions',
 }
 
@@ -125,7 +125,7 @@ def print_conflicts():
 
             color.cprint(f'{nested_1("Package")}: {pkg_name}:')
             color.cprint('\tDefined as:')
-            for attr in ['spack_spec', 'compiler_spec', 'compiler']:
+            for attr in ['pkg_spec', 'compiler_spec', 'compiler']:
                 if attr in definitions[pkg_name]:
                     attr_def = definitions[pkg_name][attr]
                     if attr_def:

--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -495,13 +495,13 @@ def workspace_push_to_cache(args):
 
 
 def workspace_push_to_cache_setup_parser(subparser):
-    """push workspace envs to a given spack buildcache"""
+    """push workspace envs to a given buildcache"""
 
     subparser.add_argument(
         '-d', dest='cache_path',
         default=None,
         required=True,
-        help='Path to spack cache.')
+        help='Path to cache.')
 
     arguments.add_common_arguments(subparser, ['where', 'exclude_where', 'filter_tags'])
 
@@ -812,7 +812,7 @@ def workspace_mirror_setup_parser(subparser):
     subparser.add_argument(
         '--dry-run', dest='dry_run',
         action='store_true',
-        help='perform a dry run. Creates spack environments, ' +
+        help='perform a dry run. Creates package environments, ' +
              'prints commands that would be executed ' +
              'for installation, and files that would be downloaded.')
 

--- a/lib/ramble/ramble/config.py
+++ b/lib/ramble/ramble/config.py
@@ -64,6 +64,7 @@ import ramble.schema.licenses
 import ramble.schema.mirrors
 import ramble.schema.modifiers
 import ramble.schema.spack
+import ramble.schema.software
 import ramble.schema.success_criteria
 import ramble.schema.variables
 
@@ -86,6 +87,7 @@ section_schemas = {
     'modifier_repos': ramble.schema.modifier_repos.schema,
     'modifiers': ramble.schema.modifiers.schema,
     'spack': ramble.schema.spack.schema,
+    'software': ramble.schema.software.schema,
     'success_criteria': ramble.schema.success_criteria.schema,
     'applications': ramble.schema.applications.schema,
     'variables': ramble.schema.variables.schema,

--- a/lib/ramble/ramble/language/shared_language.py
+++ b/lib/ramble/ramble/language/shared_language.py
@@ -108,7 +108,7 @@ def figure_of_merit(name, fom_regex, group_name, log_file='{log_file}', units=''
 
 
 @shared_directive('compilers')
-def define_compiler(name, spack_spec, compiler_spec=None, compiler=None):
+def define_compiler(name, pkg_spec, compiler_spec=None, compiler=None):
     """Defines the compiler that will be used with this object
 
     Adds a new compiler spec to this object. Software specs should
@@ -118,7 +118,7 @@ def define_compiler(name, spack_spec, compiler_spec=None, compiler=None):
     def _execute_define_compiler(obj):
         if hasattr(obj, 'uses_spack') and getattr(obj, 'uses_spack'):
             obj.compilers[name] = {
-                'spack_spec': spack_spec,
+                'pkg_spec': pkg_spec,
                 'compiler_spec': compiler_spec,
                 'compiler': compiler
             }
@@ -127,7 +127,7 @@ def define_compiler(name, spack_spec, compiler_spec=None, compiler=None):
 
 
 @shared_directive('software_specs')
-def software_spec(name, spack_spec, compiler_spec=None, compiler=None):
+def software_spec(name, pkg_spec, compiler_spec=None, compiler=None):
     """Defines a new software spec needed for this object.
 
     Adds a new software spec (for spack to use) that this object
@@ -145,7 +145,7 @@ def software_spec(name, spack_spec, compiler_spec=None, compiler=None):
 
             # Define the spec
             obj.software_specs[name] = {
-                'spack_spec': spack_spec,
+                'pkg_spec': pkg_spec,
                 'compiler_spec': compiler_spec,
                 'compiler': compiler
             }

--- a/lib/ramble/ramble/modifier.py
+++ b/lib/ramble/ramble/modifier.py
@@ -170,7 +170,7 @@ class ModifierBase(object, metaclass=ModifierMeta):
             for comp_name, comp_def in self.compilers.items():
                 out_str.append(rucolor.nested_2(f'\t{comp_name}:\n'))
                 out_str.append(rucolor.nested_3('\t\tSpack Spec:') +
-                               f'{comp_def["spack_spec"].replace("@", "@@")}\n')
+                               f'{comp_def["pkg_spec"].replace("@", "@@")}\n')
 
                 if 'compiler_spec' in comp_def and comp_def['compiler_spec']:
                     out_str.append(rucolor.nested_3('\t\tCompiler Spec:\n') +
@@ -186,7 +186,7 @@ class ModifierBase(object, metaclass=ModifierMeta):
             for spec_name, spec_def in self.software_specs.items():
                 out_str.append(rucolor.nested_2(f'\t{spec_name}:\n'))
                 out_str.append(rucolor.nested_3('\t\tSpack Spec:') +
-                               f'{spec_def["spack_spec"].replace("@", "@@")}\n')
+                               f'{spec_def["pkg_spec"].replace("@", "@@")}\n')
 
                 if 'compiler_spec' in spec_def and spec_def['compiler_spec']:
                     out_str.append(rucolor.nested_3('\t\tCompiler Spec:') +

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -43,7 +43,7 @@ class namespace:
     where = 'where'
 
     # For software definitions
-    spack = 'spack'
+    software = 'software'
     external_env = 'external_spack_env'
 
     # v2 configs

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -49,7 +49,7 @@ class namespace:
     # v2 configs
     packages = 'packages'
     environments = 'environments'
-    spack_spec = 'spack_spec'
+    pkg_spec = 'pkg_spec'
     compiler_spec = 'compiler_spec'
     compiler = 'compiler'
 

--- a/lib/ramble/ramble/schema/merged.py
+++ b/lib/ramble/ramble/schema/merged.py
@@ -17,7 +17,8 @@ import ramble.schema.applications
 import ramble.schema.config
 import ramble.schema.formatted_executables
 import ramble.schema.repos
-import ramble.schema.spack
+import ramble.schema.spack  # DEPRECATED: Remove when spack is removed
+import ramble.schema.software
 import ramble.schema.success_criteria
 import ramble.schema.variables
 import ramble.schema.env_vars
@@ -31,7 +32,8 @@ properties = union_dicts(
     ramble.schema.config.properties,
     ramble.schema.formatted_executables.properties,
     ramble.schema.repos.properties,
-    ramble.schema.spack.properties,
+    ramble.schema.spack.properties,  # DEPRECATED: Remove when spack is removed
+    ramble.schema.software.properties,
     ramble.schema.success_criteria.properties,
     ramble.schema.variables.properties,
     ramble.schema.env_vars.properties,

--- a/lib/ramble/ramble/schema/software.py
+++ b/lib/ramble/ramble/schema/software.py
@@ -33,7 +33,7 @@ properties = {
                             'default': None,
                         },
                     },
-                    # Additional properies are of the form:
+                    # Additional properties are of the form:
                     #    <pkg_manager_name>_pkg_spec:
                     #    <pkg_manager_name>_compiler_spec:
                     #    <pkg_manager_name>_compiler:

--- a/lib/ramble/ramble/schema/software.py
+++ b/lib/ramble/ramble/schema/software.py
@@ -6,16 +6,16 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-"""Schema for spack.yaml configuration file.
+"""Schema for software.yaml configuration file.
 
-.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/spack.py
+.. literalinclude:: _ramble_root/lib/ramble/ramble/schema/software.py
    :lines: 12-
 """  # noqa E501
 
 
 #: Properties for inclusion in other schemas
 properties = {
-    'spack': {
+    'software': {
         'type': 'object',
         'properties': {
             'packages': {
@@ -23,7 +23,7 @@ properties = {
                 'additionalProperties': {
                     'type': 'object',
                     'properties': {
-                        'spack_spec': {'type': 'string'},
+                        'pkg_spec': {'type': 'string'},
                         'compiler_spec': {
                             'type': 'string',
                             'default': None,
@@ -33,7 +33,11 @@ properties = {
                             'default': None,
                         },
                     },
-                    'additionalProperties': False,
+                    # Additional properies are of the form:
+                    #    <pkg_manager_name>_pkg_spec:
+                    #    <pkg_manager_name>_compiler_spec:
+                    #    <pkg_manager_name>_compiler:
+                    'additionalProperties': True,
                     'default': {}
                 },
             },
@@ -44,17 +48,15 @@ properties = {
                 'additionalProperties': {
                     'type': 'object',
                     'properties': {
-                        'external_spack_env': {
-                            'type': 'string',
-                            'default': None,
-                        },
                         'packages': {
                             'type': 'array',
                             'items': {'type': 'string'},
                             'default': []
                         },
                     },
-                    'additionalProperties': False,
+                    'additionalProperties': {
+                        'type': 'string'
+                    },
                     'default': {}
                 }
             }
@@ -68,37 +70,8 @@ properties = {
 #: Full schema with metadata
 schema = {
     '$schema': 'http://json-schema.org/schema#',
-    'title': 'Spack software configuration file schema',
+    'title': 'Software configuration file schema',
     'type': 'object',
     'additionalProperties': False,
     'properties': properties,
 }
-
-
-def update(data):
-
-    changed = False
-
-    """
-    This entire section is deprecated.
-    Replicate this into a `software` section instead.
-    """
-
-    old_data = data.copy()
-
-    pkg_keymap = {
-        'spack_spec': 'pkg_spec',
-        'compiler': 'compiler',
-        'compiler_spec': 'compiler_spec',
-    }
-
-    if 'packages' in old_data:
-        for pkg_name, pkg_def in old_data['packages'].items():
-            for key, newkey in pkg_keymap.items():
-                if key in pkg_def:
-                    if key in data['packages'][pkg_name]:
-                        del data['packages'][pkg_name][key]
-                    changed = True
-                    data['packages'][pkg_name][newkey] = pkg_def[key]
-
-    return changed

--- a/lib/ramble/ramble/schema/spack.py
+++ b/lib/ramble/ramble/schema/spack.py
@@ -23,7 +23,7 @@ properties = {
                 'additionalProperties': {
                     'type': 'object',
                     'properties': {
-                        'spack_spec': {'type': 'string'},
+                        'pkg_spec': {'type': 'string'},
                         'compiler_spec': {
                             'type': 'string',
                             'default': None,
@@ -84,21 +84,16 @@ def update(data):
     Replicate this into a `software` section instead.
     """
 
-    old_data = data.copy()
-
     pkg_keymap = {
         'spack_spec': 'pkg_spec',
-        'compiler': 'compiler',
-        'compiler_spec': 'compiler_spec',
     }
 
-    if 'packages' in old_data:
-        for pkg_name, pkg_def in old_data['packages'].items():
+    if 'packages' in data:
+        for pkg_name in data['packages']:
+
             for key, newkey in pkg_keymap.items():
-                if key in pkg_def:
-                    if key in data['packages'][pkg_name]:
-                        del data['packages'][pkg_name][key]
+                if key in data['packages'][pkg_name] and newkey not in data['packages'][pkg_name]:
                     changed = True
-                    data['packages'][pkg_name][newkey] = pkg_def[key]
+                    data['packages'][pkg_name][newkey] = data['packages'][pkg_name][key]
 
     return changed

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -420,7 +420,7 @@ class SoftwareEnvironments(object):
         """
 
         self._workspace = workspace
-        self._spack_dict = workspace.get_spack_dict().copy()
+        self._software_dict = workspace.get_software_dict().copy()
         self._environment_templates = {}
         self._package_templates = {}
         self._rendered_packages = {}
@@ -476,8 +476,8 @@ class SoftwareEnvironments(object):
     def _define_templates(self):
         """Process software dictionary to generate templates"""
 
-        if namespace.packages in self._spack_dict:
-            for pkg_template, pkg_info in self._spack_dict[namespace.packages].items():
+        if namespace.packages in self._software_dict:
+            for pkg_template, pkg_info in self._software_dict[namespace.packages].items():
                 spec = pkg_info['pkg_spec'] if 'pkg_spec' in pkg_info else pkg_info['spec']
                 compiler = pkg_info['compiler'] \
                     if 'compiler' in pkg_info and pkg_info['compiler'] else None
@@ -488,8 +488,8 @@ class SoftwareEnvironments(object):
                 )
                 self._package_templates[pkg_template] = new_pkg
 
-        if namespace.environments in self._spack_dict:
-            for env_template, env_info in self._spack_dict[namespace.environments].items():
+        if namespace.environments in self._software_dict:
+            for env_template, env_info in self._software_dict[namespace.environments].items():
                 if namespace.external_env in env_info and env_info[namespace.external_env]:
                     # External environments are considered rendered
                     new_env = ExternalEnvironment(env_template, env_info[namespace.external_env])

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -478,7 +478,7 @@ class SoftwareEnvironments(object):
 
         if namespace.packages in self._spack_dict:
             for pkg_template, pkg_info in self._spack_dict[namespace.packages].items():
-                spec = pkg_info['spack_spec'] if 'spack_spec' in pkg_info else pkg_info['spec']
+                spec = pkg_info['pkg_spec'] if 'pkg_spec' in pkg_info else pkg_info['spec']
                 compiler = pkg_info['compiler'] \
                     if 'compiler' in pkg_info and pkg_info['compiler'] else None
                 compiler_spec = pkg_info['compiler_spec'] \

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -214,38 +214,38 @@ def add_input_file(app_inst, input_num=1, func_type=func_types.directive):
 @deprecation.fail_if_not_removed
 def add_compiler(app_inst, spec_num=1, func_type=func_types.directive):
     spec_name = 'Compiler%spec_num'
-    spec_spack_spec = f'compiler_base@{spec_num}.0 +var1 ~var2'
+    spec_pkg_spec = f'compiler_base@{spec_num}.0 +var1 ~var2'
     spec_compiler_spec = 'compiler1_base@{spec_num}'
 
     spec_defs = {}
     spec_defs[spec_name] = {
-        'spack_spec': spec_spack_spec,
+        'pkg_spec': spec_pkg_spec,
         'compiler_spec': spec_compiler_spec
     }
 
     if func_type == func_types.directive:
-        define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        define_compiler(spec_name, pkg_spec=spec_pkg_spec,  # noqa: F405
                         compiler_spec=spec_compiler_spec)(app_inst)
     elif func_type == func_types.method:
-        app_inst.define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        app_inst.define_compiler(spec_name, pkg_spec=spec_pkg_spec,  # noqa: F405
                                  compiler_spec=spec_compiler_spec)
     else:
         assert False
 
     spec_name = 'OtherCompiler%spec_num'
-    spec_spack_spec = f'compiler_base@{spec_num}.1 +var1 ~var2 target=x86_64'
+    spec_pkg_spec = f'compiler_base@{spec_num}.1 +var1 ~var2 target=x86_64'
     spec_compiler_spec = 'compiler2_base@{spec_num}'
 
     spec_defs[spec_name] = {
-        'spack_spec': spec_spack_spec,
+        'pkg_spec': spec_pkg_spec,
         'compiler_spec': spec_compiler_spec
     }
 
     if func_type == func_types.directive:
-        define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: f405
+        define_compiler(spec_name, pkg_spec=spec_pkg_spec,  # noqa: f405
                         compiler_spec=spec_compiler_spec)(app_inst)
     elif func_type == func_types.method:
-        app_inst.define_compiler(spec_name, spack_spec=spec_spack_spec,  # noqa: F405
+        app_inst.define_compiler(spec_name, pkg_spec=spec_pkg_spec,  # noqa: F405
                                  compiler_spec=spec_compiler_spec)
     else:
         assert False
@@ -255,42 +255,42 @@ def add_compiler(app_inst, spec_num=1, func_type=func_types.directive):
 
 def add_software_spec(app_inst, spec_num=1, func_type=func_types.directive):
     spec_name = 'NoMPISpec%s' % spec_num
-    spec_spack_spec = f'NoMPISpec@{spec_num} +var1 ~var2 target=x86_64'
+    spec_pkg_spec = f'NoMPISpec@{spec_num} +var1 ~var2 target=x86_64'
     spec_compiler = 'spec_compiler1@1.1'
 
     spec_defs = {}
     spec_defs[spec_name] = {
-        'spack_spec': spec_spack_spec,
+        'pkg_spec': spec_pkg_spec,
         'compiler': spec_compiler
     }
 
     if func_type == func_types.directive:
         software_spec(spec_name,  # noqa: F405
-                      spack_spec=spec_spack_spec,
+                      pkg_spec=spec_pkg_spec,
                       compiler=spec_compiler)(app_inst)
     elif func_type == func_types.method:
         app_inst.software_spec(spec_name,  # noqa: F405
-                               spack_spec=spec_spack_spec,
+                               pkg_spec=spec_pkg_spec,
                                compiler=spec_compiler)
     else:
         assert False
 
     spec_name = 'MPISpec%s' % spec_num
-    spec_spack_spec = f'MPISpec@{spec_num} +var1 ~var2 target=x86_64'
+    spec_pkg_spec = f'MPISpec@{spec_num} +var1 ~var2 target=x86_64'
     spec_compiler = 'spec_compiler1@1.1'
 
     spec_defs[spec_name] = {
-        'spack_spec': spec_spack_spec,
+        'pkg_spec': spec_pkg_spec,
         'compiler': spec_compiler
     }
 
     if func_type == func_types.directive:
         software_spec(spec_name,  # noqa: F405
-                      spack_spec=spec_spack_spec,
+                      pkg_spec=spec_pkg_spec,
                       compiler=spec_compiler)(app_inst)
     elif func_type == func_types.method:
         app_inst.software_spec(spec_name,  # noqa: F405
-                               spack_spec=spec_spack_spec,
+                               pkg_spec=spec_pkg_spec,
                                compiler=spec_compiler)
     else:
         assert False

--- a/lib/ramble/ramble/test/application_tests.py
+++ b/lib/ramble/ramble/test/application_tests.py
@@ -488,7 +488,7 @@ ramble:
               variables:
                 n_nodes: '2'
 
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -127,31 +127,33 @@ env_vars:
     FOO: bar'''
 
 
-def test_merged_spack_section(mock_low_high_config):
+# DEPRECATED: Remove `spack` when removed
+@pytest.mark.parametrize('section_key', ['spack', 'software'])
+def test_merged_software_section(mock_low_high_config, section_key):
     low_path = mock_low_high_config.scopes['low'].path
     high_path = mock_low_high_config.scopes['high'].path
 
     fs.mkdirp(low_path)
     fs.mkdirp(high_path)
 
-    with open(os.path.join(low_path, 'spack.yaml'), 'w') as f:
-        f.write('''\
-spack:
+    with open(os.path.join(low_path, f'{section_key}.yaml'), 'w') as f:
+        f.write(f'''\
+{section_key}:
   packages:
     gcc:
       pkg_spec: gcc@4.8.5
 ''')
 
-    with open(os.path.join(high_path, 'spack.yaml'), 'w') as f:
-        f.write('''\
-spack:
+    with open(os.path.join(high_path, f'{section_key}.yaml'), 'w') as f:
+        f.write(f'''\
+{section_key}:
   packages:
     zlib:
       pkg_spec: zlib
       compiler: gcc
 ''')
 
-    assert config('get', 'spack').strip() == '''spack:
+    assert config('get', section_key).strip() == f'''{section_key}:
   packages:
     zlib:
       pkg_spec: zlib
@@ -293,7 +295,7 @@ def test_config_get_gets_ramble_yaml(mutable_mock_workspace_path, mutable_mock_a
         config_output = config('get')
 
         expected_keys = ['applications', 'variables', 'env_vars',
-                         'spack', 'mpi_command', 'batch_submit']
+                         'software', 'mpi_command', 'batch_submit']
 
         for key in expected_keys:
             assert key in config_output

--- a/lib/ramble/ramble/test/cmd/config.py
+++ b/lib/ramble/ramble/test/cmd/config.py
@@ -139,7 +139,7 @@ def test_merged_spack_section(mock_low_high_config):
 spack:
   packages:
     gcc:
-      spack_spec: gcc@4.8.5
+      pkg_spec: gcc@4.8.5
 ''')
 
     with open(os.path.join(high_path, 'spack.yaml'), 'w') as f:
@@ -147,17 +147,17 @@ spack:
 spack:
   packages:
     zlib:
-      spack_spec: zlib
+      pkg_spec: zlib
       compiler: gcc
 ''')
 
     assert config('get', 'spack').strip() == '''spack:
   packages:
     zlib:
-      spack_spec: zlib
+      pkg_spec: zlib
       compiler: gcc
     gcc:
-      spack_spec: gcc@4.8.5'''
+      pkg_spec: gcc@4.8.5'''
 
 
 def test_merged_success_criteria_section(mock_low_high_config):

--- a/lib/ramble/ramble/test/cmd/info.py
+++ b/lib/ramble/ramble/test/cmd/info.py
@@ -76,7 +76,7 @@ def test_spack_info_software(app_query):
         'Pipeline "setup" Phases:',
         'Pipeline "analyze" Phases:',
         'Tags:',
-        'spack_spec =',
+        'pkg_spec =',
         'compiler =',
     )
 
@@ -96,7 +96,7 @@ def test_mock_spack_info_software(mock_applications, app_query):
         'Pipeline "analyze" Phases:',
         'Tags:',
         'Package Manager Configs:',
-        'spack_spec =',
+        'pkg_spec =',
     )
 
     out = info(app_query)

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -198,7 +198,7 @@ ramble:
   spack:
     packages:
       zlib:
-        spack_spec: 'zlib'
+        pkg_spec: 'zlib'
     environments:
       zlib:
         packages:
@@ -251,7 +251,7 @@ ramble:
   spack:
     packages:
       zlib:
-        spack_spec: 'zlib'
+        pkg_spec: 'zlib'
     environments:
       zlib:
         packages:
@@ -468,12 +468,12 @@ ramble:
     ws1._re_read()
 
     assert search_files_for_string([config_path], 'packages: {}') is True
-    assert search_files_for_string([config_path], 'spack_spec: zlib') is False
+    assert search_files_for_string([config_path], 'pkg_spec: zlib') is False
 
     workspace('concretize', global_args=['-w', workspace_name])
 
     assert search_files_for_string([config_path], 'packages: {}') is False
-    assert search_files_for_string([config_path], 'spack_spec: zlib') is True
+    assert search_files_for_string([config_path], 'pkg_spec: zlib') is True
 
 
 def test_concretize_nothing():
@@ -486,12 +486,12 @@ def test_concretize_nothing():
         check_basic(ws)
 
         assert search_files_for_string([ws.config_file_path], 'packages: {}') is True
-        assert search_files_for_string([ws.config_file_path], 'spack_spec:') is False
+        assert search_files_for_string([ws.config_file_path], 'pkg_spec:') is False
 
         ws.concretize()
 
         assert search_files_for_string([ws.config_file_path], 'packages: {}') is True
-        assert search_files_for_string([ws.config_file_path], 'spack_spec:') is False
+        assert search_files_for_string([ws.config_file_path], 'pkg_spec:') is False
 
 
 def test_concretize_concrete_config():
@@ -525,7 +525,7 @@ ramble:
   spack:
     packages:
       zlib:
-        spack_spec: 'zlib'
+        pkg_spec: 'zlib'
     environments:
       zlib:
         packages:
@@ -579,7 +579,7 @@ ramble:
   spack:
     packages:
       zlib-test:
-        spack_spec: 'zlib-test'
+        pkg_spec: 'zlib-test'
     environments:
       zlib-test:
         packages:
@@ -1898,11 +1898,11 @@ ramble:
   spack:
     packages:
       zlib:
-        spack_spec: zlib
+        pkg_spec: zlib
       zlib-configs:
-        spack_spec: zlib-configs
+        pkg_spec: zlib-configs
       unused-pkg:
-        spack_spec: unused
+        pkg_spec: unused
     environments:
       zlib:
         packages:
@@ -1928,7 +1928,7 @@ applications:
 spack:
   packages:
     pkg_not_in_ws_config:
-      spack_spec: 'gcc@10.5.0'
+      pkg_spec: 'gcc@10.5.0'
       compiler_spec: gcc@10.5.0
 """
 
@@ -1949,11 +1949,11 @@ spack:
 
     ws1._re_read()
 
-    assert search_files_for_string([ws_config_path], 'spack_spec: zlib') is True
+    assert search_files_for_string([ws_config_path], 'pkg_spec: zlib') is True
     assert search_files_for_string([ws_config_path], 'unused-pkg') is True
     assert search_files_for_string([ws_config_path], 'unused-env') is True
     assert search_files_for_string([ws_config_path], 'unused_exp_template') is True
-    assert search_files_for_string([ws_config_path], 'spack_spec: zlib-configs') is True
+    assert search_files_for_string([ws_config_path], 'pkg_spec: zlib-configs') is True
     assert search_files_for_string([ws_config_path], 'app_not_in_ws_config') is False
     assert search_files_for_string([ws_config_path], 'pkg_not_in_ws_config') is False
 
@@ -1961,12 +1961,12 @@ spack:
 
     print(ws_config_path)
 
-    assert search_files_for_string([ws_config_path], 'spack_spec: zlib') is True  # keep used pkg
+    assert search_files_for_string([ws_config_path], 'pkg_spec: zlib') is True  # keep used pkg
     assert search_files_for_string([ws_config_path], 'unused-pkg') is False  # remove unused pkg
     assert search_files_for_string([ws_config_path], 'unused-env') is False  # remove unused env
     # remove unused experiment template and associated pkgs/envs
     assert search_files_for_string([ws_config_path], 'unused_exp_template') is False
-    assert search_files_for_string([ws_config_path], 'spack_spec: zlib-configs') is False
+    assert search_files_for_string([ws_config_path], 'pkg_spec: zlib-configs') is False
     # ensure apps/pkgs/envs are not merged into workspace config from other config files
     assert search_files_for_string([ws_config_path], 'app_not_in_ws_config') is False
     assert search_files_for_string([ws_config_path], 'pkg_not_in_ws_config') is False

--- a/lib/ramble/ramble/test/cmd/workspace.py
+++ b/lib/ramble/ramble/test/cmd/workspace.py
@@ -195,7 +195,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages:
       zlib:
         pkg_spec: 'zlib'
@@ -248,7 +248,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages:
       zlib:
         pkg_spec: 'zlib'
@@ -314,7 +314,7 @@ ramble:
               variables:
                 n_nodes: '2'
 
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -354,7 +354,6 @@ def test_workspace_from_template(tmpdir):
 cd "{experiment_run_dir}"
 
 cmake -DTEST=1 -h
-{spack_setup}
 
 {command}
         """
@@ -451,7 +450,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -522,7 +521,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages:
       zlib:
         pkg_spec: 'zlib'
@@ -576,7 +575,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages:
       zlib-test:
         pkg_spec: 'zlib-test'
@@ -836,7 +835,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -886,7 +885,7 @@ ramble:
                - - cells
                  - n_nodes
                - - idx
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -954,7 +953,7 @@ ramble:
               variables:
                 n_nodes: [1, 2, 4]
                 idx: [1, 2, 3, 4, 5, 6]
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1002,7 +1001,7 @@ ramble:
               matrices:
                 - - n_nodes
                 - - idx
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1046,7 +1045,7 @@ ramble:
             exp_series_{foo}:
               matrices:
                 - - foo
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1089,7 +1088,7 @@ ramble:
                 foo: '1'
               matrices:
                 - - foo
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1133,7 +1132,7 @@ ramble:
               matrices:
                 - - foo
                 - - foo
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1180,7 +1179,7 @@ ramble:
             exp_series_{foo}:
               variables:
                 foo: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1205,21 +1204,21 @@ ramble:
         write_config(ws_path, test_config)
 
         with ramble.workspace.Workspace(ws_path) as ws:
-            spack_dict = ws.get_spack_dict()
-            print(f'spack_dict before = {spack_dict}')
+            software_dict = ws.get_software_dict()
+            print(f'software_dict before = {software_dict}')
 
         workspace('concretize', global_args=workspace_flags)
 
         with ramble.workspace.Workspace(ws_path) as ws:
-            spack_dict = ws.get_spack_dict()
-            assert spack_dict[namespace.environments]
+            software_dict = ws.get_software_dict()
+            assert software_dict[namespace.environments]
 
         write_config(ws_path, test_config)
 
         workspace('concretize', global_args=workspace_flags)
         with ramble.workspace.Workspace(ws_path) as ws:
-            spack_dict = ws.get_spack_dict()
-            assert spack_dict[namespace.environments]
+            software_dict = ws.get_software_dict()
+            assert software_dict[namespace.environments]
 
 
 def test_workspace_archive():
@@ -1238,7 +1237,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1327,7 +1326,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1386,7 +1385,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1463,7 +1462,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1545,7 +1544,7 @@ ramble:
             test_experiment:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1627,7 +1626,7 @@ ramble:
         test_wl:
           experiments:
             test_experiment: {}
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1691,7 +1690,7 @@ ramble:
                 n_nodes: '2'
   include:
      - '%s'
-  spack:
+  software:
     packages: {}
     environments: {}
 """ % inc_file
@@ -1726,7 +1725,7 @@ ramble:
         test_wl:
           experiments:
             test_experiment: {}
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1788,7 +1787,7 @@ ramble:
                     use_mpi: false
                     redirect: '{log_file}'
                     output_capture: '&>'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1850,7 +1849,7 @@ ramble:
                 - exp_level_cmd
                 - wl_level_cmd
                 - app_level_cmd
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -1895,7 +1894,7 @@ ramble:
               template: True
               variables:
                 n_nodes: '1'
-  spack:
+  software:
     packages:
       zlib:
         pkg_spec: zlib
@@ -1924,8 +1923,8 @@ applications:
             variables:
               n_ranks: 1
 """
-    test_spack_config = """
-spack:
+    test_software_config = """
+software:
   packages:
     pkg_not_in_ws_config:
       pkg_spec: 'gcc@10.5.0'
@@ -1938,14 +1937,14 @@ spack:
 
     ws_config_path = os.path.join(ws1.config_dir, ramble.workspace.config_file_name)
     app_config_path = os.path.join(ws1.config_dir, 'applications.yaml')
-    spack_config_path = os.path.join(ws1.config_dir, 'spack.yaml')
+    software_config_path = os.path.join(ws1.config_dir, 'software.yaml')
 
     with open(ws_config_path, 'w+') as f:
         f.write(test_ws_config)
     with open(app_config_path, 'w+') as f:
         f.write(test_app_config)
-    with open(spack_config_path, 'w+') as f:
-        f.write(test_spack_config)
+    with open(software_config_path, 'w+') as f:
+        f.write(test_software_config)
 
     ws1._re_read()
 

--- a/lib/ramble/ramble/test/concretize_builtin.py
+++ b/lib/ramble/ramble/test/concretize_builtin.py
@@ -23,7 +23,7 @@ workspace = RambleCommand('workspace')
 def test_concretize_does_not_set_required(mutable_config, mutable_mock_workspace_path):
     """
     Verify that concretizing an application with required set to True
-    does not insert a required statement into spack spec.
+    does not insert a required statement into software dict.
     """
 
     test_config = """
@@ -67,7 +67,7 @@ ramble:
                 n_nodes: ['1', '2', '4', '8', '16']
               matrix:
               - n_nodes
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
+++ b/lib/ramble/ramble/test/end_to_end/analyze_fom_output.py
@@ -41,7 +41,7 @@ ramble:
             test:
               variables:
                 n_nodes: '1'
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -96,15 +96,15 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@9.3.0 target=x86_64
+        pkg_spec: gcc@9.3.0 target=x86_64
       impi2018:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       imb:
-        spack_spec: intel-mpi-benchmarks
+        pkg_spec: intel-mpi-benchmarks
         compiler: gcc
       gromacs:
-        spack_spec: gromacs
+        pkg_spec: gromacs
         compiler: gcc
     environments:
       intel-mpi-benchmarks:

--- a/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
+++ b/lib/ramble/ramble/test/end_to_end/chained_experiment_var_inheritance.py
@@ -93,7 +93,7 @@ ramble:
                 - n_ranks
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@9.3.0 target=x86_64

--- a/lib/ramble/ramble/test/end_to_end/config_section_env_vars.py
+++ b/lib/ramble/ramble/test/end_to_end/config_section_env_vars.py
@@ -43,7 +43,7 @@ ramble:
             simple_test:
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/custom_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/custom_executables.py
@@ -81,7 +81,7 @@ ramble:
                 set:
                   MY_VAR: 'TEST'
                   OTHER_ENV_VAR: 'ANOTHER_TEST'
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/define_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/define_package_paths.py
@@ -50,9 +50,9 @@ ramble:
   spack:
     packages:
       gromacs:
-        spack_spec: gromacs
+        pkg_spec: gromacs
       intel-mpi:
-        spack_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.11.0
     environments:
       gromacs:
         packages:
@@ -117,9 +117,9 @@ ramble:
   spack:
     packages:
       gromacs:
-        spack_spec: gromacs
+        pkg_spec: gromacs
       intel-mpi:
-        spack_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.11.0
     environments:
       gromacs:
         packages:

--- a/lib/ramble/ramble/test/end_to_end/define_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/define_package_paths.py
@@ -47,7 +47,7 @@ ramble:
             test2:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages:
       gromacs:
         pkg_spec: gromacs
@@ -114,7 +114,7 @@ ramble:
             test2:
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages:
       gromacs:
         pkg_spec: gromacs

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -82,7 +82,7 @@ ramble:
                 order: 'before_root'
               variables:
                 n_nodes: '2'
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@9.3.0 target=x86_64

--- a/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_chained_experiments.py
@@ -85,15 +85,15 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@9.3.0 target=x86_64
+        pkg_spec: gcc@9.3.0 target=x86_64
       impi2018:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       imb:
-        spack_spec: intel-mpi-benchmarks
+        pkg_spec: intel-mpi-benchmarks
         compiler: gcc
       gromacs:
-        spack_spec: gromacs
+        pkg_spec: gromacs
         compiler: gcc
     environments:
       intel-mpi-benchmarks:

--- a/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
@@ -51,7 +51,7 @@ ramble:
             test{{n_nodes}}_{{env_name}}:
               variables:
                 n_nodes: '1'
-  spack:
+  software:
     packages: {{}}
     environments:
       wrfv4:

--- a/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
@@ -45,7 +45,7 @@ ramble:
               variables:
                 n_nodes: '1'
                 test_id: [1, 2]
-  spack:
+  software:
     packages:
       zlib:
         pkg_spec: zlib

--- a/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_series_contains_package_paths.py
@@ -48,7 +48,7 @@ ramble:
   spack:
     packages:
       zlib:
-        spack_spec: zlib
+        pkg_spec: zlib
     environments:
       zlib:
         packages:

--- a/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
+++ b/lib/ramble/ramble/test/end_to_end/env_var_builtin.py
@@ -59,7 +59,7 @@ ramble:
               env_vars:
                 set:
                   MY_VAR: 'TEST'
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -143,7 +143,7 @@ ramble:
             simple_test:
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/exclusive_filtered_vector_workloads.py
@@ -41,7 +41,7 @@ ramble:
               variables:
                 application_workload: ['parallel' ,'serial', 'local']
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/expanded_fom_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/expanded_fom_dry_run.py
@@ -42,7 +42,7 @@ ramble:
               variables:
                 n_nodes: 1
                 n_ranks: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -85,7 +85,7 @@ ramble:
                 - partitions
                 where:
                 - '{n_nodes} == 16'
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_excludes.py
@@ -88,15 +88,15 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel-mpi:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       wrfv4:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc
       wrfv4-portable:
-        spack_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
+        pkg_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
           nesting=basic ~chem ~pnetcdf target=x86_64'
         compiler: gcc
     environments:

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -63,12 +63,12 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel-mpi:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       gromacs:
-        spack_spec: gromacs@2021.6
+        pkg_spec: gromacs@2021.6
         compiler: gcc
     environments:
       gromacs:

--- a/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
+++ b/lib/ramble/ramble/test/end_to_end/experiment_repeats.py
@@ -60,7 +60,7 @@ ramble:
                 n_threads: '1'
                 size: '0003'
                 type: 'pme'
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -79,7 +79,7 @@ ramble:
               - nodes
               - environments
               - partitions
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/explicit_zips.py
+++ b/lib/ramble/ramble/test/end_to_end/explicit_zips.py
@@ -82,15 +82,15 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel-mpi:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       wrfv4:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc
       wrfv4-portable:
-        spack_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
+        pkg_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
           nesting=basic ~chem ~pnetcdf target=x86_64'
         compiler: gcc
     environments:

--- a/lib/ramble/ramble/test/end_to_end/formatted_executables.py
+++ b/lib/ramble/ramble/test/end_to_end/formatted_executables.py
@@ -57,7 +57,7 @@ ramble:
                   join_separator: '\n'
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -113,7 +113,7 @@ ramble:
               variables:
                 var_exec_name: 'nothing'
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/globbing_patterns.py
+++ b/lib/ramble/ramble/test/end_to_end/globbing_patterns.py
@@ -52,7 +52,7 @@ ramble:
               modifiers:
                 - name: glob-patterns-mod
                   mode: test-glob
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
+++ b/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
@@ -41,7 +41,7 @@ ramble:
               variables:
                 n_nodes: '1'
                 size: '0000.96'
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
+++ b/lib/ramble/ramble/test/end_to_end/gromacs_size_expansion.py
@@ -44,12 +44,12 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel-mpi:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       gromacs:
-        spack_spec: gromacs
+        pkg_spec: gromacs
         compiler: gcc
     environments:
       gromacs:

--- a/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/inclusive_filtered_vector_workloads.py
@@ -41,7 +41,7 @@ ramble:
               variables:
                 application_workload: ['parallel' ,'serial', 'local']
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/known_applications.py
+++ b/lib/ramble/ramble/test/end_to_end/known_applications.py
@@ -70,7 +70,7 @@ def test_known_applications(application, capsys):
                 n_ranks: '1'
                 n_nodes: '1'
                 processes_per_node: '1'\n""")
-            f.write("""  spack:
+            f.write("""  software:
     packages: {}
     environments: {}\n""")
 

--- a/lib/ramble/ramble/test/end_to_end/merge_config_files.py
+++ b/lib/ramble/ramble/test/end_to_end/merge_config_files.py
@@ -40,7 +40,7 @@ applications:
 spack:
   packages:
     zlib:
-      spack_spec: zlib@1.2.12
+      pkg_spec: zlib@1.2.12
   environments:
     zlib:
       packages:
@@ -88,4 +88,4 @@ ramble:
             assert 'ensure_installed' in data
             assert 'test_experiment' in data
             assert 'zlib' in data
-            assert 'spack_spec: zlib@1.2.12' in data
+            assert 'pkg_spec: zlib@1.2.12' in data

--- a/lib/ramble/ramble/test/end_to_end/merge_config_files.py
+++ b/lib/ramble/ramble/test/end_to_end/merge_config_files.py
@@ -36,8 +36,8 @@ applications:
               n_ranks: '1'
 """
 
-    test_spack = """
-spack:
+    test_software = """
+software:
   packages:
     zlib:
       pkg_spec: zlib@1.2.12
@@ -54,7 +54,7 @@ ramble:
     processes_per_node: '16'
     n_threads: '1'
   applications: {}
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -70,16 +70,16 @@ ramble:
         ws._re_read()
 
         applications_file = os.path.join(ws.root, 'applications_test.yaml')
-        spack_file = os.path.join(ws.root, 'spack_test.yaml')
+        software_file = os.path.join(ws.root, 'software_test.yaml')
 
         with open(applications_file, 'w+') as f:
             f.write(test_applications)
 
-        with open(spack_file, 'w+') as f:
-            f.write(test_spack)
+        with open(software_file, 'w+') as f:
+            f.write(test_software)
 
         config('add', '-f', applications_file, global_args=['-w', workspace_name])
-        config('add', '-f', spack_file, global_args=['-w', workspace_name])
+        config('add', '-f', software_file, global_args=['-w', workspace_name])
 
         ws._re_read()
 

--- a/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
@@ -24,7 +24,7 @@ workspace = RambleCommand('workspace')
 
 
 def test_missing_required_dry_run(mutable_config, mutable_mock_workspace_path):
-    """Tests tty.die at end of ramble.application_types.spack._create_spack_env"""
+    """Tests tty.die at end of ramble.application_types.spack._create_software_env"""
     test_config = """
 ramble:
   variables:
@@ -41,7 +41,7 @@ ramble:
             eight_node:
               variables:
                 n_nodes: '8'
-  spack:
+  software:
     packages:
       gcc8:
         pkg_spec: gcc@8.2.0 target=x86_64

--- a/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/missing_required_dry_run.py
@@ -44,13 +44,13 @@ ramble:
   spack:
     packages:
       gcc8:
-        spack_spec: gcc@8.2.0 target=x86_64
+        pkg_spec: gcc@8.2.0 target=x86_64
         compiler_spec: gcc@8.2.0
       impi2018:
-        spack_spec: intel-mpi@2018.4.274 target=x86_64
+        pkg_spec: intel-mpi@2018.4.274 target=x86_64
         compiler: gcc8
       wrfv3:
-        spack_spec: my_wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf
+        pkg_spec: my_wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf
         compiler: gcc8
     environments:
       wrfv3:

--- a/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
+++ b/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
@@ -47,18 +47,18 @@ ramble:
   spack:
     packages:
       gcc8:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       gcc9:
-        spack_spec: gcc@9.3.0
+        pkg_spec: gcc@9.3.0
         compiler: gcc8
       gcc10:
-        spack_spec: gcc@10.1.0
+        pkg_spec: gcc@10.1.0
         compiler: gcc9
       intel:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc10
       wrf:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc10
     environments:
       wrfv4:

--- a/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
+++ b/lib/ramble/ramble/test/end_to_end/nested_compilers_are_installed.py
@@ -44,7 +44,7 @@ ramble:
             test{n_nodes}_{env_name}:
               variables:
                 n_nodes: '1'
-  spack:
+  software:
     packages:
       gcc8:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/package_manager_config.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_config.py
@@ -40,7 +40,7 @@ ramble:
   spack:
     packages:
       zlib:
-        spack_spec: 'zlib'
+        pkg_spec: 'zlib'
     environments:
       zlib-configs:
         packages:

--- a/lib/ramble/ramble/test/end_to_end/package_manager_config.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_config.py
@@ -37,7 +37,7 @@ ramble:
           experiments:
             test:
               variables: {}
-  spack:
+  software:
     packages:
       zlib:
         pkg_spec: 'zlib'

--- a/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
+++ b/lib/ramble/ramble/test/end_to_end/package_manager_requirements.py
@@ -40,7 +40,7 @@ ramble:
           experiments:
             test:
               variables: {}
-  spack:
+  software:
     packages: {}
     environments:
       zlib-configs:
@@ -92,7 +92,7 @@ ramble:
           experiments:
             test:
               variables: {}
-  spack:
+  software:
     packages: {}
     environments:
       zlib-configs:

--- a/lib/ramble/ramble/test/end_to_end/passthrough_variables.py
+++ b/lib/ramble/ramble/test/end_to_end/passthrough_variables.py
@@ -45,7 +45,7 @@ ramble:
             simple_test:
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -92,7 +92,7 @@ ramble:
               variables:
                 mpi_command: '{undefined_var}'
                 n_ranks: '1'
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/phase_selection.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection.py
@@ -80,15 +80,15 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel-mpi:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       wrfv4:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc
       wrfv4-portable:
-        spack_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
+        pkg_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
           nesting=basic ~chem ~pnetcdf target=x86_64'
         compiler: gcc
     environments:

--- a/lib/ramble/ramble/test/end_to_end/phase_selection.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection.py
@@ -77,7 +77,7 @@ ramble:
               matrix:
               - n_nodes
               - env_name
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
@@ -78,7 +78,7 @@ ramble:
               matrix:
               - n_nodes
               - env_name
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
+++ b/lib/ramble/ramble/test/end_to_end/phase_selection_with_dependencies.py
@@ -81,15 +81,15 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel-mpi:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       wrfv4:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc
       wrfv4-portable:
-        spack_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
+        pkg_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
           nesting=basic ~chem ~pnetcdf target=x86_64'
         compiler: gcc
     environments:

--- a/lib/ramble/ramble/test/end_to_end/shared_context.py
+++ b/lib/ramble/ramble/test/end_to_end/shared_context.py
@@ -50,7 +50,7 @@ ramble:
                 - name: test-mod
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
+++ b/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
@@ -55,9 +55,9 @@ ramble:
   spack:
     packages:
       intel-mpi:
-        spack_spec: intel-oneapi-mpi@2021.11.0
+        pkg_spec: intel-oneapi-mpi@2021.11.0
       gromacs:
-        spack_spec: gromacs
+        pkg_spec: gromacs
     environments:
       gromacs:
         packages:

--- a/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
+++ b/lib/ramble/ramble/test/end_to_end/spack_env_cache.py
@@ -52,7 +52,7 @@ ramble:
             test4:
               variables:
                 n_nodes: '1'
-  spack:
+  software:
     packages:
       intel-mpi:
         pkg_spec: intel-oneapi-mpi@2021.11.0

--- a/lib/ramble/ramble/test/end_to_end/tag_filtering.py
+++ b/lib/ramble/ramble/test/end_to_end/tag_filtering.py
@@ -73,7 +73,7 @@ ramble:
               - second
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/test_configvar_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/test_configvar_dry_run.py
@@ -55,12 +55,12 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       openfoam:
-        spack_spec: openfoam-org
+        pkg_spec: openfoam-org
         compiler: gcc
     environments:
       openfoam:

--- a/lib/ramble/ramble/test/end_to_end/test_configvar_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/test_configvar_dry_run.py
@@ -52,7 +52,7 @@ ramble:
             "{}_test_{{{var_name}}}":
               variables:
                 n_ranks: "{{{var_name}}}"
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
+++ b/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
@@ -47,16 +47,16 @@ ramble:
   spack:
     packages:
       gcc8:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       gcc9:
-        spack_spec: gcc@9.3.0
+        pkg_spec: gcc@9.3.0
       gcc10:
-        spack_spec: gcc@10.1.0
+        pkg_spec: gcc@10.1.0
       intel:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc8
       wrf:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc8
     environments:
       wrfv4:

--- a/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
+++ b/lib/ramble/ramble/test/end_to_end/unused_compilers_are_skipped.py
@@ -44,7 +44,7 @@ ramble:
             test{n_nodes}_{env_name}:
               variables:
                 n_nodes: '1'
-  spack:
+  software:
     packages:
       gcc8:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/vector_workloads.py
+++ b/lib/ramble/ramble/test/end_to_end/vector_workloads.py
@@ -41,7 +41,7 @@ ramble:
               variables:
                 application_workload: ['parallel' ,'serial', 'local']
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -68,7 +68,7 @@ ramble:
               matrix:
               - n_nodes
               - env_name
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
+++ b/lib/ramble/ramble/test/end_to_end/wrfv4_dry_run.py
@@ -71,15 +71,15 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel-mpi:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       wrfv4:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc
       wrfv4-portable:
-        spack_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
+        pkg_spec: 'wrf@4.2 build_type=dm+sm compile_type=em_real
           nesting=basic ~chem ~pnetcdf target=x86_64'
         compiler: gcc
     environments:

--- a/lib/ramble/ramble/test/mirror_tests.py
+++ b/lib/ramble/ramble/test/mirror_tests.py
@@ -125,7 +125,7 @@ ramble:
                 n_ranks: '1'
                 n_nodes: '1'
                 processes_per_node: '1'
-  spack:
+  software:
     packages: {{}}
     environments: {{}}
 """

--- a/lib/ramble/ramble/test/modifier_application.py
+++ b/lib/ramble/ramble/test/modifier_application.py
@@ -47,15 +47,15 @@ ramble:
   spack:
     packages:
       gcc:
-        spack_spec: gcc@8.5.0
+        pkg_spec: gcc@8.5.0
       intel-mpi:
-        spack_spec: intel-mpi@2018.4.274
+        pkg_spec: intel-mpi@2018.4.274
         compiler: gcc
       wrfv4:
-        spack_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
+        pkg_spec: wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf
         compiler: gcc
       intel-oneapi-vtune:
-        spack_spec: intel-oneapi-vtune
+        pkg_spec: intel-oneapi-vtune
     environments:
       wrfv4:
         packages:

--- a/lib/ramble/ramble/test/modifier_application.py
+++ b/lib/ramble/ramble/test/modifier_application.py
@@ -44,7 +44,7 @@ ramble:
                 - '*'
               variables:
                 n_nodes: '1'
-  spack:
+  software:
     packages:
       gcc:
         pkg_spec: gcc@8.5.0

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -190,21 +190,21 @@ def test_variable_modification_missing_mode(mod_class, func_type):
 
 def add_software_spec(mod_inst, spec_num=1, func_type=func_types.directive):
     spec_name = f'SoftwarePackage{spec_num}'
-    spack_spec = 'pkg@1.1 target=x86_64'
+    pkg_spec = 'pkg@1.1 target=x86_64'
     compiler_spec = 'pkg@1.1'
     compiler = 'gcc9'
 
     spec_def = {
         'name': spec_name,
-        'spack_spec': spack_spec,
+        'pkg_spec': pkg_spec,
         'compiler_spec': compiler_spec,
         'compiler': compiler
     }
 
     if func_type == func_types.directive:
-        software_spec(spec_name, spack_spec, compiler_spec, compiler)(mod_inst)
+        software_spec(spec_name, pkg_spec, compiler_spec, compiler)(mod_inst)
     elif func_type == func_types.method:
-        mod_inst.software_spec(spec_name, spack_spec, compiler_spec, compiler)
+        mod_inst.software_spec(spec_name, pkg_spec, compiler_spec, compiler)
     else:
         assert False
 
@@ -219,7 +219,7 @@ def test_software_spec_directive(mod_class, func_type):
     test_defs = []
     test_defs.append(add_software_spec(mod_inst, func_type=func_type).copy())
 
-    expected_attrs = ['spack_spec', 'compiler_spec', 'compiler']
+    expected_attrs = ['pkg_spec', 'compiler_spec', 'compiler']
 
     if mod_inst.uses_spack:
         assert hasattr(mod_inst, 'software_specs')
@@ -235,21 +235,21 @@ def test_software_spec_directive(mod_class, func_type):
 
 def add_compiler(mod_inst, spec_num=1, func_type=func_types.directive):
     spec_name = f'CompilerPackage{spec_num}'
-    spack_spec = 'compiler@1.1 target=x86_64'
+    pkg_spec = 'compiler@1.1 target=x86_64'
     compiler_spec = 'compiler@1.1'
     compiler = None
 
     spec_def = {
         'name': spec_name,
-        'spack_spec': spack_spec,
+        'pkg_spec': pkg_spec,
         'compiler_spec': compiler_spec,
         'compiler': compiler
     }
 
     if func_type == func_types.directive:
-        define_compiler(spec_name, spack_spec, compiler_spec, compiler)(mod_inst)
+        define_compiler(spec_name, pkg_spec, compiler_spec, compiler)(mod_inst)
     elif func_type == func_types.method:
-        mod_inst.define_compiler(spec_name, spack_spec, compiler_spec, compiler)
+        mod_inst.define_compiler(spec_name, pkg_spec, compiler_spec, compiler)
     else:
         assert False
 
@@ -264,7 +264,7 @@ def test_define_compiler_directive(mod_class, func_type):
     test_defs = []
     test_defs.append(add_compiler(mod_inst, func_type=func_type).copy())
 
-    expected_attrs = ['spack_spec', 'compiler_spec', 'compiler']
+    expected_attrs = ['pkg_spec', 'compiler_spec', 'compiler']
 
     if mod_inst.uses_spack:
         assert hasattr(mod_inst, 'compilers')

--- a/lib/ramble/ramble/test/software_environment.py
+++ b/lib/ramble/ramble/test/software_environment.py
@@ -29,7 +29,7 @@ def test_basic_software_environment(request, mutable_mock_workspace_path):
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic'] = {
@@ -66,7 +66,7 @@ def test_software_environments_no_packages(request, mutable_mock_workspace_path)
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['environments'] = {
@@ -96,7 +96,7 @@ def test_software_environments_no_rendered_packages(request, mutable_mock_worksp
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['environments'] = {
@@ -127,7 +127,7 @@ def test_template_software_environments(request, mutable_mock_workspace_path):
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic-{pkg_test}'] = {
@@ -167,7 +167,7 @@ def test_multi_template_software_environments(request, mutable_mock_workspace_pa
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic1-{pkg_test}'] = {
@@ -229,7 +229,7 @@ def test_undefined_package_errors(request, mutable_mock_workspace_path):
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic-{pkg_test}'] = {
@@ -266,7 +266,7 @@ def test_invalid_packages_error(request, mutable_mock_workspace_path):
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic-{pkg_test}'] = {
@@ -313,7 +313,7 @@ def test_invalid_environment_error(request, mutable_mock_workspace_path):
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic1-{pkg_test}'] = {
@@ -363,7 +363,7 @@ def test_undefined_compiler_errors(request, mutable_mock_workspace_path):
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic'] = {
@@ -398,7 +398,7 @@ def test_compiler_in_environment_warns(request, mutable_mock_workspace_path, cap
     assert ws_name in workspace('list')
 
     with ramble.workspace.read(ws_name) as ws:
-        spack_dict = ws.get_spack_dict()
+        spack_dict = ws.get_software_dict()
 
         spack_dict['packages'] = {}
         spack_dict['packages']['test_comp'] = {

--- a/lib/ramble/ramble/test/software_environment.py
+++ b/lib/ramble/ramble/test/software_environment.py
@@ -33,7 +33,7 @@ def test_basic_software_environment(request, mutable_mock_workspace_path):
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic'] = {
-            'spack_spec': 'basic@1.1'
+            'pkg_spec': 'basic@1.1'
         }
         spack_dict['environments'] = {
             'basic': {
@@ -131,7 +131,7 @@ def test_template_software_environments(request, mutable_mock_workspace_path):
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic-{pkg_test}'] = {
-            'spack_spec': 'basic@1.1'
+            'pkg_spec': 'basic@1.1'
         }
         spack_dict['environments'] = {
             'basic-{env_test}': {
@@ -171,10 +171,10 @@ def test_multi_template_software_environments(request, mutable_mock_workspace_pa
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic1-{pkg_test}'] = {
-            'spack_spec': 'basic@1.1'
+            'pkg_spec': 'basic@1.1'
         }
         spack_dict['packages']['basic2-{pkg_test}'] = {
-            'spack_spec': 'basic@1.1'
+            'pkg_spec': 'basic@1.1'
         }
         spack_dict['environments'] = {
             'all-basic-{env_test}': {
@@ -233,7 +233,7 @@ def test_undefined_package_errors(request, mutable_mock_workspace_path):
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic-{pkg_test}'] = {
-            'spack_spec': 'basic@{pkg_ver}'
+            'pkg_spec': 'basic@{pkg_ver}'
         }
         spack_dict['environments'] = {
             'all-basic-{env_test}': {
@@ -270,7 +270,7 @@ def test_invalid_packages_error(request, mutable_mock_workspace_path):
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic-{pkg_test}'] = {
-            'spack_spec': 'basic@{pkg_ver}'
+            'pkg_spec': 'basic@{pkg_ver}'
         }
         spack_dict['environments'] = {
             'all-basic-{env_test}': {
@@ -317,10 +317,10 @@ def test_invalid_environment_error(request, mutable_mock_workspace_path):
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic1-{pkg_test}'] = {
-            'spack_spec': 'basic@1.1'
+            'pkg_spec': 'basic@1.1'
         }
         spack_dict['packages']['basic2-{pkg_test}'] = {
-            'spack_spec': 'basic@1.1'
+            'pkg_spec': 'basic@1.1'
         }
         spack_dict['environments'] = {
             'all-basic-{env_test}': {
@@ -367,7 +367,7 @@ def test_undefined_compiler_errors(request, mutable_mock_workspace_path):
 
         spack_dict['packages'] = {}
         spack_dict['packages']['basic'] = {
-            'spack_spec': 'basic@1.1',
+            'pkg_spec': 'basic@1.1',
             'compiler': 'foo_comp'
         }
         spack_dict['environments'] = {
@@ -402,10 +402,10 @@ def test_compiler_in_environment_warns(request, mutable_mock_workspace_path, cap
 
         spack_dict['packages'] = {}
         spack_dict['packages']['test_comp'] = {
-            'spack_spec': 'comp@2.1'
+            'pkg_spec': 'comp@2.1'
         }
         spack_dict['packages']['basic'] = {
-            'spack_spec': 'basic@1.1',
+            'pkg_spec': 'basic@1.1',
             'compiler': 'test_comp'
         }
         spack_dict['environments'] = {

--- a/lib/ramble/ramble/test/success_criteria/always_print_foms.py
+++ b/lib/ramble/ramble/test/success_criteria/always_print_foms.py
@@ -42,7 +42,7 @@ ramble:
             simple_test:
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/success_criteria/repeat_success_strict.py
+++ b/lib/ramble/ramble/test/success_criteria/repeat_success_strict.py
@@ -45,7 +45,7 @@ ramble:
               n_repeats: 2
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/success_criteria/success_functions.py
+++ b/lib/ramble/ramble/test/success_criteria/success_functions.py
@@ -42,7 +42,7 @@ ramble:
             simple_test:
               variables:
                 n_nodes: 1
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -47,7 +47,7 @@ ramble:
               env_vars:
                 set:
                   MY_VAR: 'TEST'
-  spack:
+  software:
     packages:
       zlib:
         pkg_spec: zlib

--- a/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
+++ b/lib/ramble/ramble/test/workspace_hashing/unsetup_workspace_cannot_analyze.py
@@ -50,7 +50,7 @@ ramble:
   spack:
     packages:
       zlib:
-        spack_spec: zlib
+        pkg_spec: zlib
     environments:
       zlib:
         packages:

--- a/lib/ramble/ramble/test/workspace_hashing/workspace_name_does_not_change_hash.py
+++ b/lib/ramble/ramble/test/workspace_hashing/workspace_name_does_not_change_hash.py
@@ -45,7 +45,7 @@ ramble:
               env_vars:
                 set:
                   MY_VAR: 'TEST'
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py
+++ b/lib/ramble/ramble/test/workspace_hashing/workspace_setup_creates_inventory.py
@@ -46,7 +46,7 @@ ramble:
               env_vars:
                 set:
                   MY_VAR: 'TEST'
-  spack:
+  software:
     packages: {}
     environments: {}
 """

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -137,7 +137,7 @@ ramble:
     batch_submit: '{execute_experiment}'
     processes_per_node: -1
   applications: {}
-  spack:
+  software:
     packages: {}
     environments: {}
 """
@@ -866,11 +866,12 @@ class Workspace(object):
         return env_context[namespace.external_env]
 
     def concretize(self):
-        spack_dict = self.get_spack_dict()
+        full_software_dict = self.get_software_dict()
 
         if not self.force_concretize:
             try:
-                if spack_dict[namespace.packages] or spack_dict[namespace.environments]:
+                if full_software_dict[namespace.packages] or \
+                        full_software_dict[namespace.environments]:
                     raise RambleWorkspaceError('Cannot concretize an already concretized '
                                                'workspace. To overwrite the current configuration '
                                                'with the default software configuration, use '
@@ -878,17 +879,17 @@ class Workspace(object):
             except KeyError:
                 pass
 
-        spack_dict = syaml.syaml_dict()
+        full_software_dict = syaml.syaml_dict()
 
-        if namespace.packages not in spack_dict or \
-                not spack_dict[namespace.packages]:
-            spack_dict[namespace.packages] = syaml.syaml_dict()
-        if namespace.environments not in spack_dict or \
-                not spack_dict[namespace.environments]:
-            spack_dict[namespace.environments] = syaml.syaml_dict()
+        if namespace.packages not in full_software_dict or \
+                not full_software_dict[namespace.packages]:
+            full_software_dict[namespace.packages] = syaml.syaml_dict()
+        if namespace.environments not in full_software_dict or \
+                not full_software_dict[namespace.environments]:
+            full_software_dict[namespace.environments] = syaml.syaml_dict()
 
-        packages_dict = spack_dict[namespace.packages]
-        environments_dict = spack_dict[namespace.environments]
+        packages_dict = full_software_dict[namespace.packages]
+        environments_dict = full_software_dict[namespace.environments]
 
         self.software_environments = \
             ramble.software_environments.SoftwareEnvironments(self)
@@ -909,16 +910,16 @@ class Workspace(object):
                     if comp not in packages_dict:
                         packages_dict[comp] = syaml.syaml_dict()
                         packages_dict[comp]['pkg_spec'] = info['pkg_spec']
-                        ramble.config.add(f'spack:packages:{comp}:pkg_spec:{info["pkg_spec"]}',
+                        ramble.config.add(f'software:packages:{comp}:pkg_spec:{info["pkg_spec"]}',
                                           scope=self.ws_file_config_scope_name())
                         if 'compiler_spec' in info and info['compiler_spec']:
                             packages_dict[comp]['compiler_spec'] = info['compiler_spec']
-                            config_path = f'spack:packages:{comp}:' + \
+                            config_path = f'software:packages:{comp}:' + \
                                 f'compiler_spec:{info["compiler_spec"]}'
                             ramble.config.add(config_path, scope=self.ws_file_config_scope_name())
                         if 'compiler' in info and info['compiler']:
                             packages_dict[comp]['compiler'] = info['compiler']
-                            config_path = f'spack:packages:{comp}:' + \
+                            config_path = f'software:packages:{comp}:' + \
                                 f'compiler:{info["compiler"]}'
                             ramble.config.add(config_path, scope=self.ws_file_config_scope_name())
                     elif not specs_equiv(info, packages_dict[comp]):
@@ -960,7 +961,7 @@ class Workspace(object):
                     if spec_name not in app_packages:
                         app_packages.append(spec_name)
 
-        ramble.config.config.update_config('spack', spack_dict,
+        ramble.config.config.update_config('software', full_software_dict,
                                            scope=self.ws_file_config_scope_name())
 
         return
@@ -1199,10 +1200,10 @@ class Workspace(object):
         software_environments = self.software_environments
         experiment_set = self.build_experiment_set()
 
-        spack_dict = ramble.config.config.get_config(namespace.spack,
-                                                     scope=self.ws_file_config_scope_name())
-        package_dict = spack_dict[namespace.packages]
-        environments_dict = spack_dict[namespace.environments]
+        software_dict = ramble.config.config.get_config(namespace.software,
+                                                        scope=self.ws_file_config_scope_name())
+        package_dict = software_dict[namespace.packages]
+        environments_dict = software_dict[namespace.environments]
 
         tty.debug('Removing configurations that do not spark joy.')
         for pkg in software_environments.unused_packages():
@@ -1214,7 +1215,7 @@ class Workspace(object):
                 tty.debug(f'Removing {env.name} from Spack environments')
                 environments_dict.pop(env.name)
 
-        ramble.config.config.update_config(namespace.spack, spack_dict,
+        ramble.config.config.update_config(namespace.software, software_dict,
                                            scope=self.ws_file_config_scope_name())
 
     @property
@@ -1466,9 +1467,29 @@ class Workspace(object):
         """Return a dict of workspace zips"""
         return ramble.config.config.get_config('zips')
 
-    def get_spack_dict(self):
-        """Return the spack dictionary for this workspace"""
-        return ramble.config.config.get_config(namespace.spack)
+    def get_software_dict(self):
+        """Return the software dictionary for this workspace"""
+        # DEPRECATED: Remove once the spack config section is completely removed
+        spack_dict = ramble.config.config.get_config('spack')
+        software_dict = ramble.config.config.get_config(namespace.software)
+
+        print_warnings = True
+        if hasattr(self, '_printed_deprecations'):
+            print_warnings = not self._printed_deprecations
+
+        if spack_dict and software_dict:
+            if print_warnings:
+                logger.warn('Both a spack and software configuration section are defined.')
+                logger.warn('The spack configuration section is deprecated.')
+                logger.warn('The software configuration section will be used.')
+            return software_dict
+        elif spack_dict:
+            if print_warnings:
+                logger.warn('The spack configuration section is deprecated')
+                logger.warn('Please update to the software dict.')
+            return spack_dict
+
+        return software_dict
 
     def get_applications(self):
         """Get the dictionary of applications"""

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -908,8 +908,8 @@ class Workspace(object):
                 for comp, info in compiler_dict.items():
                     if comp not in packages_dict:
                         packages_dict[comp] = syaml.syaml_dict()
-                        packages_dict[comp]['spack_spec'] = info['spack_spec']
-                        ramble.config.add(f'spack:packages:{comp}:spack_spec:{info["spack_spec"]}',
+                        packages_dict[comp]['pkg_spec'] = info['pkg_spec']
+                        ramble.config.add(f'spack:packages:{comp}:pkg_spec:{info["pkg_spec"]}',
                                           scope=self.ws_file_config_scope_name())
                         if 'compiler_spec' in info and info['compiler_spec']:
                             packages_dict[comp]['compiler_spec'] = info['compiler_spec']
@@ -944,7 +944,7 @@ class Workspace(object):
                     logger.debug(f'    Found spec: {spec_name}')
                     if spec_name not in packages_dict:
                         packages_dict[spec_name] = syaml.syaml_dict()
-                        packages_dict[spec_name]['spack_spec'] = info['spack_spec']
+                        packages_dict[spec_name]['pkg_spec'] = info['pkg_spec']
                         if 'compiler_spec' in info and info['compiler_spec']:
                             packages_dict[spec_name]['compiler_spec'] = info['compiler_spec']
                         if 'compiler' in info and info['compiler']:

--- a/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
@@ -12,7 +12,7 @@ from ramble.appkit import *
 class ZlibConfigs(SpackApplication):
     name = "zlib-configs"
 
-    software_spec('zlib', spack_spec='zlib')
+    software_spec('zlib', pkg_spec='zlib')
 
     executable('list_lib', 'ls {zlib}/lib', use_mpi=False)
 

--- a/var/ramble/repos/builtin.mock/applications/zlib/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib/application.py
@@ -12,7 +12,7 @@ from ramble.appkit import *
 class Zlib(SpackApplication):
     name = "zlib"
 
-    software_spec('zlib', spack_spec='zlib')
+    software_spec('zlib', pkg_spec='zlib')
 
     executable('list_lib', 'ls {zlib}/lib', use_mpi=False)
 

--- a/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
@@ -18,15 +18,15 @@ class SpackFailedReqs(SpackModifier):
     mode('default', description='This is the default mode for the spack-failed-reqs modifier')
 
     define_compiler('mod_compiler',
-                    spack_spec='mod_compiler@1.1 target=x86_64',
+                    pkg_spec='mod_compiler@1.1 target=x86_64',
                     compiler_spec='mod_compiler@1.1')
 
     software_spec('mod_package1',
-                  spack_spec='mod_package1@1.1',
+                  pkg_spec='mod_package1@1.1',
                   compiler='mod_compiler')
 
     software_spec('mod_package2',
-                  spack_spec='mod_package2@1.1',
+                  pkg_spec='mod_package2@1.1',
                   compiler='mod_compiler')
 
     package_manager_requirement('list not-a-package', validation_type='not_empty', modes=['default'])

--- a/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
@@ -20,15 +20,15 @@ class SpackMod(SpackModifier):
     package_manager_config('enable_debug', 'config:debug:true')
 
     define_compiler('mod_compiler',
-                    spack_spec='mod_compiler@1.1 target=x86_64',
+                    pkg_spec='mod_compiler@1.1 target=x86_64',
                     compiler_spec='mod_compiler@1.1')
 
     software_spec('mod_package1',
-                  spack_spec='mod_package1@1.1',
+                  pkg_spec='mod_package1@1.1',
                   compiler='mod_compiler')
 
     software_spec('mod_package2',
-                  spack_spec='mod_package2@1.1',
+                  pkg_spec='mod_package2@1.1',
                   compiler='mod_compiler')
 
     package_manager_requirement('list not-a-package', validation_type='empty', modes=['default'])

--- a/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/test-mod/modifier.py
@@ -31,7 +31,7 @@ class TestMod(BasicModifier):
 
     variable_modification('analysis_log', '{experiment_run_dir}/test_analysis.log', method='set', modes=['test'])
 
-    software_spec('analysis_spec', spack_spec='analysis_pkg@1.1', compiler='gcc')
+    software_spec('analysis_spec', pkg_spec='analysis_pkg@1.1', compiler='gcc')
 
     fom_regex = r'(?P<context>fom_context)(?P<fom>.*)'
 

--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -20,12 +20,12 @@ class Cloverleaf(SpackApplication):
 
     tags('cfd', 'fluid', 'dynamics', 'euler', 'miniapp', 'minibenchmark', 'mini-benchmark')
 
-    define_compiler('gcc12', spack_spec='gcc@12.2.0')
+    define_compiler('gcc12', pkg_spec='gcc@12.2.0')
 
-    software_spec('ompi414', spack_spec='openmpi@4.1.4 +legacylaunchers +cxx',
+    software_spec('ompi414', pkg_spec='openmpi@4.1.4 +legacylaunchers +cxx',
                   compiler='gcc12')
     software_spec('cloverleaf',
-                  spack_spec='cloverleaf@1.1 build=ref',
+                  pkg_spec='cloverleaf@1.1 build=ref',
                   compiler='gcc12')
 
     required_package('cloverleaf')

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -19,9 +19,9 @@ class Gromacs(SpackApplication):
 
     tags('molecular-dynamics')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
-    software_spec('gromacs', spack_spec='gromacs@2020.5', compiler='gcc9')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
+    software_spec('impi2018', pkg_spec='intel-mpi@2018.4.274')
+    software_spec('gromacs', pkg_spec='gromacs@2020.5', compiler='gcc9')
 
     executable('pre-process', '{grompp} ' +
                '-f {input_path}/{type}.mdp ' +

--- a/var/ramble/repos/builtin/applications/hmmer/application.py
+++ b/var/ramble/repos/builtin/applications/hmmer/application.py
@@ -28,11 +28,11 @@ class Hmmer(SpackApplication):
 
     tags('molecular-dynamics', 'hidden-markov-models', 'bio-molecule')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
-    software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
+    software_spec('impi_2018', pkg_spec='intel-mpi@2018.4.274')
 
-    software_spec('hmmer', spack_spec='hmmer@3.3.2', compiler='gcc9')
+    software_spec('hmmer', pkg_spec='hmmer@3.3.2', compiler='gcc9')
 
     # This would ideally not use the current_release, as the package will need to be manually updated per release
     # Here current_release == 'Pfam36.0'

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -28,13 +28,13 @@ class Hpcc(SpackApplication):
 
     tags('benchmark-app', 'mini-app', 'benchmark', 'DGEMM')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
     software_spec('impi2018',
-                  spack_spec='intel-mpi@2018.4.274')
+                  pkg_spec='intel-mpi@2018.4.274')
 
     software_spec('hpcc',
-                  spack_spec='hpcc@1.5.0',
+                  pkg_spec='hpcc@1.5.0',
                   compiler='gcc9')
 
     required_package('hpcc')

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -19,13 +19,13 @@ class Hpcg(SpackApplication):
 
     tags('benchmark-app', 'mini-app', 'benchmark')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
     software_spec('impi2018',
-                  spack_spec='intel-mpi@2018.4.274')
+                  pkg_spec='intel-mpi@2018.4.274')
 
     software_spec('hpcg',
-                  spack_spec='hpcg@3.1 +openmp',
+                  pkg_spec='hpcg@3.1 +openmp',
                   compiler='gcc9')
 
     required_package('hpcg')

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -25,11 +25,11 @@ class Hpl(SpackApplication):
 
     tags('benchmark-app', 'benchmark', 'linpack')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
-    software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
+    software_spec('impi_2018', pkg_spec='intel-mpi@2018.4.274')
 
-    software_spec('hpl', spack_spec='hpl@2.3 +openmp', compiler='gcc9')
+    software_spec('hpl', pkg_spec='hpl@2.3 +openmp', compiler='gcc9')
 
     required_package('hpl')
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -25,9 +25,9 @@ class IntelHpl(SpackApplication):
 
     tags('benchmark-app', 'benchmark', 'linpack', 'optimized', 'intel', 'mkl')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
-    software_spec('imkl_2023p1', spack_spec='intel-oneapi-mkl@2023.1.0 threads=openmp', compiler='gcc9')
-    software_spec('impi_2018', spack_spec='intel-mpi@2018.4.274')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
+    software_spec('imkl_2023p1', pkg_spec='intel-oneapi-mkl@2023.1.0 threads=openmp', compiler='gcc9')
+    software_spec('impi_2018', pkg_spec='intel-mpi@2018.4.274')
 
     required_package('intel-oneapi-mkl')
 

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -29,10 +29,10 @@ class IntelMpiBenchmarks(SpackApplication):
 
     tags('micro-benchmark', 'benchmark', 'mpi')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
+    software_spec('impi2018', pkg_spec='intel-mpi@2018.4.274')
     software_spec('intel-mpi-benchmarks',
-                  spack_spec='intel-mpi-benchmarks@2019.6',
+                  pkg_spec='intel-mpi-benchmarks@2019.6',
                   compiler='gcc9')
 
     required_package('intel-mpi-benchmarks')

--- a/var/ramble/repos/builtin/applications/ior/application.py
+++ b/var/ramble/repos/builtin/applications/ior/application.py
@@ -18,9 +18,9 @@ class Ior(SpackApplication):
 
     tags('synthetic-benchmarks', 'IO')
 
-    define_compiler('gcc', spack_spec='gcc')
-    software_spec('openmpi', spack_spec='openmpi')
-    software_spec('ior', spack_spec='ior', compiler='gcc')
+    define_compiler('gcc', pkg_spec='gcc')
+    software_spec('openmpi', pkg_spec='openmpi')
+    software_spec('ior', pkg_spec='ior', compiler='gcc')
 
     required_package('ior')
 

--- a/var/ramble/repos/builtin/applications/iperf2/application.py
+++ b/var/ramble/repos/builtin/applications/iperf2/application.py
@@ -17,10 +17,10 @@ class Iperf2(SpackApplication):
 
     maintainers('rfbgo')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
     software_spec('iperf2',
-                  spack_spec='iperf2@2.0.12',
+                  pkg_spec='iperf2@2.0.12',
                   compiler='gcc9')
 
     required_package('iperf2')

--- a/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
+++ b/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
@@ -40,7 +40,7 @@ ramble:
             test_server:
                 variables:
                     additional_flags: "-t 120"
-spack:
+software:
   compilers:
     gcc9:
       pkg_spec: gcc@9.3.0

--- a/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
+++ b/var/ramble/repos/builtin/applications/iperf2/examples/manual_run/ramble.yaml
@@ -43,10 +43,10 @@ ramble:
 spack:
   compilers:
     gcc9:
-      spack_spec: gcc@9.3.0
+      pkg_spec: gcc@9.3.0
   mpi_libraries: {}
   applications:
     iperf2:
       iperf2:
-        spack_spec: iperf2@2.0.12
+        pkg_spec: iperf2@2.0.12
         compiler: gcc9

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -18,12 +18,12 @@ class Lammps(SpackApplication):
 
     tags('molecular-dynamics')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
+    software_spec('impi2018', pkg_spec='intel-mpi@2018.4.274')
 
     software_spec('lammps',
-                  spack_spec='lammps@20220623.4 +opt+manybody+molecule+kspace+rigid+openmp+openmp-package+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth',
+                  pkg_spec='lammps@20220623.4 +opt+manybody+molecule+kspace+rigid+openmp+openmp-package+asphere+dpd-basic+dpd-meso+dpd-react+dpd-smooth',
                   compiler='gcc9')
 
     required_package('lammps')

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -19,13 +19,13 @@ class Lulesh(SpackApplication):
 
     tags('proxy-app', 'mini-app')
 
-    define_compiler('gcc13', spack_spec='gcc@13.1.0')
+    define_compiler('gcc13', pkg_spec='gcc@13.1.0')
 
     software_spec('impi2018',
-                  spack_spec='intel-mpi@2018.4.274')
+                  pkg_spec='intel-mpi@2018.4.274')
 
     software_spec('lulesh',
-                  spack_spec='lulesh@2.0.3 +openmp',
+                  pkg_spec='lulesh@2.0.3 +openmp',
                   compiler='gcc13')
 
     required_package('lulesh')

--- a/var/ramble/repos/builtin/applications/md-test/application.py
+++ b/var/ramble/repos/builtin/applications/md-test/application.py
@@ -18,12 +18,12 @@ class MdTest(SpackApplication):
 
     tags('synthetic-benchmarks', 'IO')
 
-    define_compiler('gcc', spack_spec='gcc')
-    software_spec('openmpi', spack_spec='openmpi')
+    define_compiler('gcc', pkg_spec='gcc')
+    software_spec('openmpi', pkg_spec='openmpi')
 
     # The IOR spack package also includes MDTest, but we implement it as a
     # separate application in ramble
-    software_spec('ior', spack_spec='ior', compiler='gcc')
+    software_spec('ior', pkg_spec='ior', compiler='gcc')
 
     required_package('ior')
 

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -19,12 +19,12 @@ class Minixyce(SpackApplication):
 
     tags('circuitdesign', 'miniapp', 'mini-app', 'minibenchmark', 'mini-benchmark')
 
-    define_compiler('gcc12', spack_spec="gcc@12.2.0")
+    define_compiler('gcc12', pkg_spec="gcc@12.2.0")
 
-    software_spec('ompi415cxx', spack_spec='openmpi@4.1.5 +legacylaunchers +cxx',
+    software_spec('ompi415cxx', pkg_spec='openmpi@4.1.5 +legacylaunchers +cxx',
                   compiler='gcc12')
 
-    software_spec('minixyce', spack_spec='minixyce@1.0 +mpi',
+    software_spec('minixyce', pkg_spec='minixyce@1.0 +mpi',
                   compiler='gcc12')
 
     required_package('minixyce')

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -21,13 +21,13 @@ class Namd(SpackApplication):
 
     tags('molecular-dynamics', 'charm++', 'task-parallelism')
 
-    define_compiler('gcc12', spack_spec='gcc@12.2.0')
+    define_compiler('gcc12', pkg_spec='gcc@12.2.0')
 
-    software_spec('impi2021p8', spack_spec='intel-oneapi-mpi@2021.8.0')
+    software_spec('impi2021p8', pkg_spec='intel-oneapi-mpi@2021.8.0')
 
-    software_spec('charmpp', spack_spec='charmpp backend=mpi build-target=charm++', compiler='gcc12')
+    software_spec('charmpp', pkg_spec='charmpp backend=mpi build-target=charm++', compiler='gcc12')
 
-    software_spec('namd', spack_spec='namd@2.14 interface=tcl', compiler='gcc12')
+    software_spec('namd', pkg_spec='namd@2.14 interface=tcl', compiler='gcc12')
 
     required_package('namd')
 

--- a/var/ramble/repos/builtin/applications/nvbandwidth/application.py
+++ b/var/ramble/repos/builtin/applications/nvbandwidth/application.py
@@ -17,7 +17,7 @@ class Nvbandwidth(SpackApplication):
 
     tags('synthetic-benchmarks')
 
-    software_spec('nvbandwidth', spack_spec='nvbandwidth')
+    software_spec('nvbandwidth', pkg_spec='nvbandwidth')
 
     required_package('nvbandwidth')
 

--- a/var/ramble/repos/builtin/applications/openfoam/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam/application.py
@@ -19,17 +19,17 @@ class Openfoam(SpackApplication):
 
     tags('cfd', 'fluid', 'dynamics')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
     software_spec('ompi412',
-                  spack_spec='openmpi@4.1.2 +legacylaunchers +cxx',
+                  pkg_spec='openmpi@4.1.2 +legacylaunchers +cxx',
                   compiler='gcc9')
 
     software_spec('flex',
-                  spack_spec='flex@2.6.4',
+                  pkg_spec='flex@2.6.4',
                   compiler='gcc9')
     software_spec('openfoam',
-                  spack_spec='openfoam-org@7',
+                  pkg_spec='openfoam-org@7',
                   compiler='gcc9')
 
     required_package('openfoam-org')

--- a/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
@@ -23,9 +23,9 @@ class OsuMicroBenchmarks(SpackApplication):
 
     tags('synthetic-benchmarks')
 
-    define_compiler('gcc', spack_spec='gcc')
-    software_spec('openmpi', spack_spec='openmpi')
-    software_spec('osu-micro-benchmarks', spack_spec='osu-micro-benchmarks',
+    define_compiler('gcc', pkg_spec='gcc')
+    software_spec('openmpi', pkg_spec='openmpi')
+    software_spec('osu-micro-benchmarks', pkg_spec='osu-micro-benchmarks',
                   compiler='gcc')
 
     required_package('osu-micro-benchmarks')

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -19,10 +19,10 @@ class QuantumEspresso(SpackApplication):
 
     tags('electronic-structure', 'materials', 'dft', 'density-functional-theory', 'plane-waves', 'pseudopotentials')
 
-    define_compiler('gcc13', spack_spec='gcc@13.1.0')
+    define_compiler('gcc13', pkg_spec='gcc@13.1.0')
 
-    software_spec('impi2021p8', spack_spec='intel-oneapi-mpi@2021.8.0')
-    software_spec('quantum-espresso', spack_spec='quantum-espresso@7.1', compiler='gcc13')
+    software_spec('impi2021p8', pkg_spec='intel-oneapi-mpi@2021.8.0')
+    software_spec('quantum-espresso', pkg_spec='quantum-espresso@7.1', compiler='gcc13')
 
     required_package('quantum-espresso')
 

--- a/var/ramble/repos/builtin/applications/streamc/application.py
+++ b/var/ramble/repos/builtin/applications/streamc/application.py
@@ -19,10 +19,10 @@ class Streamc(SpackApplication):
 
     tags('memorybenchmark', 'microbenchmark', 'memory-benchmark', 'micro-benchmark')
 
-    define_compiler('gcc12', spack_spec='gcc@12.2.0')
+    define_compiler('gcc12', pkg_spec='gcc@12.2.0')
 
     software_spec('streamc',
-                  spack_spec='stream@5.10 +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',
+                  pkg_spec='stream@5.10 +openmp cflags="-O3 -DSTREAM_ARRAY_SIZE=80000000 -DNTIMES=20"',
                   compiler='gcc12')
 
     required_package('stream')

--- a/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
+++ b/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
@@ -19,15 +19,15 @@ class UfsWeatherModel(SpackApplication):
 
     tags('nwp', 'weather')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
-    software_spec('ompi415', spack_spec="openmpi@4.1.5", compiler='gcc9')
+    software_spec('ompi415', pkg_spec="openmpi@4.1.5", compiler='gcc9')
 
-    software_spec('python39', spack_spec="python@3.9.15", compiler='gcc9')
-    software_spec('esmf', spack_spec="esmf@8.0.1", compiler='gcc9')
+    software_spec('python39', pkg_spec="python@3.9.15", compiler='gcc9')
+    software_spec('esmf', pkg_spec="esmf@8.0.1", compiler='gcc9')
 
     software_spec('ufs-weather-model',
-                  spack_spec='ufs-weather-model@2.0.0 +avx2 +openmp', compiler='gcc9')
+                  pkg_spec='ufs-weather-model@2.0.0 +avx2 +openmp', compiler='gcc9')
 
     required_package('ufs-weather-model')
 

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -19,12 +19,12 @@ class Wrfv3(SpackApplication):
 
     tags('nwp', 'weather')
 
-    define_compiler('gcc8', spack_spec='gcc@8.2.0')
+    define_compiler('gcc8', pkg_spec='gcc@8.2.0')
 
-    software_spec('impi2018', spack_spec='intel-mpi@2018.4.274')
+    software_spec('impi2018', pkg_spec='intel-mpi@2018.4.274')
 
     software_spec('wrfv3',
-                  spack_spec='wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf',
+                  pkg_spec='wrf@3.9.1.1 build_type=dm+sm compile_type=em_real nesting=basic ~pnetcdf',
                   compiler='gcc8')
 
     required_package('wrf')

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -19,13 +19,13 @@ class Wrfv4(SpackApplication):
 
     tags('nwp', 'weather')
 
-    define_compiler('gcc9', spack_spec='gcc@9.3.0')
+    define_compiler('gcc9', pkg_spec='gcc@9.3.0')
 
-    software_spec('intel-mpi', spack_spec="intel-mpi@2018.4.274",
+    software_spec('intel-mpi', pkg_spec="intel-mpi@2018.4.274",
                   compiler='gcc9')
 
     software_spec('wrfv4',
-                  spack_spec="wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf",
+                  pkg_spec="wrf@4.2 build_type=dm+sm compile_type=em_real nesting=basic ~chem ~pnetcdf",
                   compiler='gcc9')
 
     required_package('wrf')

--- a/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
@@ -32,7 +32,7 @@ class IntelAps(SpackModifier):
 
     archive_pattern('aps_*_results_dir/*')
 
-    software_spec('intel-oneapi-vtune', spack_spec='intel-oneapi-vtune')
+    software_spec('intel-oneapi-vtune', pkg_spec='intel-oneapi-vtune')
 
     required_package('intel-oneapi-vtune')
 


### PR DESCRIPTION
This merge adds a software configuration section to Ramble, to hold package and environment definitions.