### PR TITLE
Convert software_environments to work with package_manager abstraction

### DIFF
--- a/lib/ramble/ramble/cmd/workspace.py
+++ b/lib/ramble/ramble/cmd/workspace.py
@@ -679,7 +679,9 @@ def workspace_info(args):
                     app_inst = experiment_set.get_experiment(exp_name)
                     if app_inst.package_manager is not None:
                         software_environments.render_environment(
-                            app_inst.expander.expand_var("{env_name}"), app_inst.expander
+                            app_inst.expander.expand_var("{env_name}"),
+                            app_inst.expander,
+                            app_inst.package_manager,
                         )
 
                     if print_header:

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -73,6 +73,16 @@ class PackageManagerBase(object, metaclass=PackageManagerMeta):
 
         return new_copy
 
+    def get_spec_str(self, pkg, all_pkgs, compiler):
+        """Return a spec string for the given pkg
+
+        Args:
+            pkg (RenderedPackage): Reference to a rendered package
+            all_pkgs (dict): All related packages
+            compiler (boolean): True if this pkg is used as a compiler
+        """
+        return ""
+
     def _long_print(self):
         out_str = []
         out_str.append(rucolor.section_title("Package Manager: ") + f"{self.name}\n")

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -187,7 +187,7 @@ class PackageManagerBase(object, metaclass=PackageManagerMeta):
 
         software_environments = workspace.software_environments
         software_environments.render_environment(
-            app_context, self.app_inst.expander, require=False
+            app_context, self.app_inst.expander, self.app_inst.package_manager, require=False
         )
 
         return self.app_inst.expander._used_variables

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -197,7 +197,7 @@ class PackageManagerBase(object, metaclass=PackageManagerMeta):
 
         software_environments = workspace.software_environments
         software_environments.render_environment(
-            app_context, self.app_inst.expander, self.app_inst.package_manager, require=False
+            app_context, self.app_inst.expander, self, require=False
         )
 
         return self.app_inst.expander._used_variables

--- a/lib/ramble/ramble/software_environments.py
+++ b/lib/ramble/ramble/software_environments.py
@@ -164,28 +164,7 @@ class RenderedPackage(SoftwarePackage):
         """
         if not all_packages:
             all_packages = defaultdict(dict)
-        out_str = ""
-        pm_name = self.package_manager.name
-        # TODO: This should probably be something provided by the package manager
-        if pm_name.startswith("spack"):
-            if compiler and self.compiler_spec:
-                out_str = self.compiler_spec
-            else:
-                out_str = self.spec
-
-            if compiler:
-                return out_str
-
-            if self.compiler in all_packages[pm_name]:
-                out_str += " %" + all_packages[pm_name][self.compiler].spec_str(
-                    all_packages, compiler=True
-                )
-            elif self.compiler:
-                out_str += f" (built with {self.compiler})"
-        else:
-            raise RambleSoftwareEnvironmentError(
-                f"Package {self.name} uses an unknown " f"package manager {self.package_manager}"
-            )
+        out_str = self.package_manager.get_spec_str(self, all_packages, compiler)
 
         return out_str
 

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -76,7 +76,7 @@ class SpackLightweight(PackageManagerBase):
 
             software_envs = workspace.software_environments
             software_env = software_envs.render_environment(
-                app_context, self.app_inst.expander
+                app_context, self.app_inst.expander, self
             )
 
             for compiler_spec in software_envs.compiler_specs_for_environment(
@@ -150,7 +150,7 @@ class SpackLightweight(PackageManagerBase):
             )
             software_envs = workspace.software_environments
             software_env = software_envs.render_environment(
-                env_context, self.app_inst.expander
+                env_context, self.app_inst.expander, self
             )
             if isinstance(software_env, ExternalEnvironment):
                 self.runner.copy_from_external_env(software_env.external_env)

--- a/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack-lightweight/package_manager.py
@@ -449,6 +449,30 @@ class SpackLightweight(PackageManagerBase):
     def spack_deactivate(self):
         return self.runner.generate_deactivate_command()
 
+    def get_spec_str(self, pkg, all_pkgs, compiler):
+        """Return a spec string for the given pkg
+
+        Args:
+            pkg (RenderedPackage): Reference to a rendered package
+            all_pkgs (dict): All related packages
+            compiler (boolean): True if this pkg is used as a compiler
+        """
+        if compiler and pkg.compiler_spec:
+            out_str = pkg.compiler_spec
+        else:
+            out_str = pkg.spec
+
+        if compiler:
+            return out_str
+
+        if pkg.compiler in all_pkgs[self.name]:
+            out_str += " %" + all_pkgs[self.name][pkg.compiler].spec_str(
+                all_pkgs, compiler=True
+            )
+        elif pkg.compiler:
+            out_str += f" (built with {pkg.compiler})"
+        return out_str
+
 
 spack_namespace = "spack"
 

--- a/var/ramble/repos/builtin/package_managers/spack/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/spack/package_manager.py
@@ -90,7 +90,7 @@ class Spack(SpackLightweight):
         )
         software_environments = workspace.software_environments
         software_environment = software_environments.render_environment(
-            app_context, self.app_inst.expander
+            app_context, self.app_inst.expander, self
         )
         # Try to resolve using local cache first
         unresolved_specs = []
@@ -170,7 +170,7 @@ class Spack(SpackLightweight):
         )
         software_environments = workspace.software_environments
         software_environment = software_environments.render_environment(
-            app_context, self.app_inst.expander
+            app_context, self.app_inst.expander, self
         )
 
         for pkg_spec in software_environments.package_specs_for_environment(


### PR DESCRIPTION
Update software_environments to accommodate for package_manager abstraction.

Main changes:

* Pass in package_manager instance when calling render_environment
* A template (pkg or env) can be rendered with different package managers
* Every rendered (pkg or env) has an associated package manager