### PR TITLE
Deprecate spack base classes

### DIFF
--- a/lib/ramble/ramble/application_types/spack.py
+++ b/lib/ramble/ramble/application_types/spack.py
@@ -6,7 +6,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-
+import deprecation
 from ramble.application import ApplicationBase
 import ramble.keywords
 
@@ -23,6 +23,13 @@ def subsection_title(s):
     return level1_color + s + plain_format
 
 
+@deprecation.deprecated(
+    deprecated_in="0.5.0",
+    removed_in="0.6.0",
+    current_version=str(ramble.ramble_version),
+    details="The SpackApplication class is deprecated. "
+    + "Convert instances to ExecutableApplication instead",
+)
 class SpackApplication(ApplicationBase):
     """Specialized class for applications that are installed from spack.
 

--- a/lib/ramble/ramble/modifier_types/spack.py
+++ b/lib/ramble/ramble/modifier_types/spack.py
@@ -6,10 +6,19 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+import ramble
+import deprecation
 
 from ramble.modifier import ModifierBase
 
 
+@deprecation.deprecated(
+    deprecated_in="0.5.0",
+    removed_in="0.6.0",
+    current_version=str(ramble.ramble_version),
+    details="The SpackModifier class is deprecated. "
+    + "Convert instances to BasicModifier instead",
+)
 class SpackModifier(ModifierBase):
     """Specialized class for modifiers that use spack.
 

--- a/lib/ramble/ramble/test/application_language.py
+++ b/lib/ramble/ramble/test/application_language.py
@@ -23,6 +23,7 @@ app_types = [
 func_types = enum.Enum("func_types", ["method", "directive"])
 
 
+@deprecation.fail_if_not_removed
 @pytest.mark.parametrize("app_class", app_types)
 def test_application_type_features(app_class):
     app_path = "/path/to/app"

--- a/lib/ramble/ramble/test/modifier_language.py
+++ b/lib/ramble/ramble/test/modifier_language.py
@@ -7,6 +7,7 @@
 # except according to those terms.
 """Perform tests of the Application class"""
 
+import deprecation
 import pytest
 import enum
 
@@ -30,6 +31,7 @@ def generate_mod_class(base_class):
     return GeneratedClass
 
 
+@deprecation.fail_if_not_removed
 @pytest.mark.parametrize("mod_class", mod_types)
 def test_modifier_type_features(mod_class):
     test_class = generate_mod_class(mod_class)

--- a/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib-configs/application.py
@@ -9,7 +9,7 @@
 from ramble.appkit import *
 
 
-class ZlibConfigs(SpackApplication):
+class ZlibConfigs(ExecutableApplication):
     name = "zlib-configs"
 
     software_spec("zlib", pkg_spec="zlib")
@@ -18,7 +18,9 @@ class ZlibConfigs(SpackApplication):
 
     workload("ensure_installed", executable="list_lib")
 
-    package_manager_config("enable_debug", "config:debug:true")
+    package_manager_config(
+        "enable_debug", "config:debug:true", package_manager="spack*"
+    )
 
     figure_of_merit(
         "zlib_installed",

--- a/var/ramble/repos/builtin.mock/applications/zlib/application.py
+++ b/var/ramble/repos/builtin.mock/applications/zlib/application.py
@@ -9,7 +9,7 @@
 from ramble.appkit import *
 
 
-class Zlib(SpackApplication):
+class Zlib(ExecutableApplication):
     name = "zlib"
 
     software_spec("zlib", pkg_spec="zlib")

--- a/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-failed-reqs/modifier.py
@@ -9,7 +9,7 @@
 from ramble.modkit import *  # noqa: F403
 
 
-class SpackFailedReqs(SpackModifier):
+class SpackFailedReqs(BasicModifier):
     """Define spack modifier requirements that will fail"""
 
     name = "spack-mod"

--- a/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
+++ b/var/ramble/repos/builtin.mock/modifiers/spack-mod/modifier.py
@@ -9,7 +9,7 @@
 from ramble.modkit import *  # noqa: F403
 
 
-class SpackMod(SpackModifier):
+class SpackMod(BasicModifier):
     """Define spack modifier with various software aspects"""
 
     name = "spack-mod"
@@ -18,7 +18,9 @@ class SpackMod(SpackModifier):
 
     mode("default", description="This is the default mode for the spack-mod")
 
-    package_manager_config("enable_debug", "config:debug:true")
+    package_manager_config(
+        "enable_debug", "config:debug:true", package_manager="spack*"
+    )
 
     define_compiler(
         "mod_compiler",

--- a/var/ramble/repos/builtin/applications/cloverleaf/application.py
+++ b/var/ramble/repos/builtin/applications/cloverleaf/application.py
@@ -12,7 +12,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Cloverleaf(SpackApplication):
+class Cloverleaf(ExecutableApplication):
     """Define CLOVERLEAF application"""
 
     name = "cloverleaf"
@@ -40,7 +40,7 @@ class Cloverleaf(SpackApplication):
         "cloverleaf", pkg_spec="cloverleaf@1.1 build=ref", compiler="gcc12"
     )
 
-    required_package("cloverleaf")
+    required_package("cloverleaf", package_manager="spack*")
 
     executable("execute", "clover_leaf", use_mpi=True)
 

--- a/var/ramble/repos/builtin/applications/gromacs/application.py
+++ b/var/ramble/repos/builtin/applications/gromacs/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Gromacs(SpackApplication):
+class Gromacs(ExecutableApplication):
     """Define a Gromacs application"""
 
     name = "gromacs"

--- a/var/ramble/repos/builtin/applications/hmmer/application.py
+++ b/var/ramble/repos/builtin/applications/hmmer/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Hmmer(SpackApplication):
+class Hmmer(ExecutableApplication):
     """HMMER is used for searching sequence databases for sequence homologs,
     and for making sequence alignments. It implements methods using
     probabilistic models called profile hidden Markov models (profile HMMs).

--- a/var/ramble/repos/builtin/applications/hpcc/application.py
+++ b/var/ramble/repos/builtin/applications/hpcc/application.py
@@ -10,7 +10,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Hpcc(SpackApplication):
+class Hpcc(ExecutableApplication):
     """Define the HPCC application
 
     HPCC is a collection of multiple benchmarks, which include:
@@ -35,7 +35,7 @@ class Hpcc(SpackApplication):
 
     software_spec("hpcc", pkg_spec="hpcc@1.5.0", compiler="gcc9")
 
-    required_package("hpcc")
+    required_package("hpcc", package_manager="spack*")
 
     input_file(
         "hpccinf",

--- a/var/ramble/repos/builtin/applications/hpcg/application.py
+++ b/var/ramble/repos/builtin/applications/hpcg/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Hpcg(SpackApplication):
+class Hpcg(ExecutableApplication):
     """Define HPCG application"""
 
     name = "hpcg"
@@ -26,7 +26,7 @@ class Hpcg(SpackApplication):
 
     software_spec("hpcg", pkg_spec="hpcg@3.1 +openmp", compiler="gcc9")
 
-    required_package("hpcg")
+    required_package("hpcg", package_manager="spack*")
 
     executable("execute", "xhpcg", use_mpi=True)
 

--- a/var/ramble/repos/builtin/applications/hpl/application.py
+++ b/var/ramble/repos/builtin/applications/hpl/application.py
@@ -17,7 +17,7 @@ def pad_value(val, desc):
     return "{:<14}".format(val) + desc
 
 
-class Hpl(SpackApplication):
+class Hpl(ExecutableApplication):
     """Define HPL application"""
 
     name = "hpl"
@@ -32,7 +32,7 @@ class Hpl(SpackApplication):
 
     software_spec("hpl", pkg_spec="hpl@2.3 +openmp", compiler="gcc9")
 
-    required_package("hpl")
+    required_package("hpl", package_manager="spack*")
 
     executable("execute", "xhpl", use_mpi=True)
 

--- a/var/ramble/repos/builtin/applications/intel-hpl/application.py
+++ b/var/ramble/repos/builtin/applications/intel-hpl/application.py
@@ -17,7 +17,7 @@ def pad_value(val, desc):
     return "{:<14}".format(val) + desc
 
 
-class IntelHpl(SpackApplication):
+class IntelHpl(ExecutableApplication):
     """Define HPL application using Intel MKL optimized binary from intel-oneapi-mpi package"""
 
     name = "intel-hpl"
@@ -34,7 +34,7 @@ class IntelHpl(SpackApplication):
     )
     software_spec("impi_2018", pkg_spec="intel-mpi@2018.4.274")
 
-    required_package("intel-oneapi-mkl")
+    required_package("intel-oneapi-mkl", package_manager="spack*")
 
     executable(
         "execute",

--- a/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/intel-mpi-benchmarks/application.py
@@ -15,7 +15,7 @@ from ramble.expander import Expander
 # - Check the compute nodes in a single rack using the network topology API
 
 
-class IntelMpiBenchmarks(SpackApplication):
+class IntelMpiBenchmarks(ExecutableApplication):
     """Intel MPI Benchmark application.
 
     https://www.intel.com/content/www/us/en/developer/articles/technical/intel-mpi-benchmarks.html
@@ -37,7 +37,7 @@ class IntelMpiBenchmarks(SpackApplication):
         compiler="gcc9",
     )
 
-    required_package("intel-mpi-benchmarks")
+    required_package("intel-mpi-benchmarks", package_manager="spack*")
 
     executable(
         "pingpong",

--- a/var/ramble/repos/builtin/applications/ior/application.py
+++ b/var/ramble/repos/builtin/applications/ior/application.py
@@ -10,7 +10,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Ior(SpackApplication):
+class Ior(ExecutableApplication):
     """Define the IOR parallel IO benchmark. Also includes"""
 
     name = "ior"
@@ -23,7 +23,7 @@ class Ior(SpackApplication):
     software_spec("openmpi", pkg_spec="openmpi")
     software_spec("ior", pkg_spec="ior", compiler="gcc")
 
-    required_package("ior")
+    required_package("ior", package_manager="spack*")
 
     workload("multi-file", executable="ior")
 

--- a/var/ramble/repos/builtin/applications/iperf2/application.py
+++ b/var/ramble/repos/builtin/applications/iperf2/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Iperf2(SpackApplication):
+class Iperf2(ExecutableApplication):
     """Define the iperf2 application"""
 
     name = "iperf2"
@@ -22,7 +22,7 @@ class Iperf2(SpackApplication):
 
     software_spec("iperf2", pkg_spec="iperf2@2.0.12", compiler="gcc9")
 
-    required_package("iperf2")
+    required_package("iperf2", package_manager="spack*")
 
     # Need to support these use cases:
     # iperf -s // set up server

--- a/var/ramble/repos/builtin/applications/lammps/application.py
+++ b/var/ramble/repos/builtin/applications/lammps/application.py
@@ -10,7 +10,7 @@ import os
 from ramble.appkit import *
 
 
-class Lammps(SpackApplication):
+class Lammps(ExecutableApplication):
     """Define LAMMPS application"""
 
     name = "lammps"
@@ -29,7 +29,7 @@ class Lammps(SpackApplication):
         compiler="gcc9",
     )
 
-    required_package("lammps")
+    required_package("lammps", package_manager="spack*")
 
     input_file(
         "leonard-jones",

--- a/var/ramble/repos/builtin/applications/lulesh/application.py
+++ b/var/ramble/repos/builtin/applications/lulesh/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Lulesh(SpackApplication):
+class Lulesh(ExecutableApplication):
     """Define LULESH application"""
 
     name = "LULESH"
@@ -26,7 +26,7 @@ class Lulesh(SpackApplication):
 
     software_spec("lulesh", pkg_spec="lulesh@2.0.3 +openmp", compiler="gcc13")
 
-    required_package("lulesh")
+    required_package("lulesh", package_manager="spack*")
 
     executable("execute", "lulesh2.0 {flags}", use_mpi=True)
 

--- a/var/ramble/repos/builtin/applications/md-test/application.py
+++ b/var/ramble/repos/builtin/applications/md-test/application.py
@@ -10,7 +10,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class MdTest(SpackApplication):
+class MdTest(ExecutableApplication):
     """Define the MDTest parallel IO benchmark"""
 
     name = "md-test"
@@ -26,7 +26,7 @@ class MdTest(SpackApplication):
     # separate application in ramble
     software_spec("ior", pkg_spec="ior", compiler="gcc")
 
-    required_package("ior")
+    required_package("ior", package_manager="spack*")
 
     workload("multi-file", executable="ior")
 

--- a/var/ramble/repos/builtin/applications/minixyce/application.py
+++ b/var/ramble/repos/builtin/applications/minixyce/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Minixyce(SpackApplication):
+class Minixyce(ExecutableApplication):
     """Define miniXyce application"""
 
     name = "minixyce"
@@ -36,7 +36,7 @@ class Minixyce(SpackApplication):
 
     software_spec("minixyce", pkg_spec="minixyce@1.0 +mpi", compiler="gcc12")
 
-    required_package("minixyce")
+    required_package("minixyce", package_manager="spack*")
 
     executable(
         "execute",

--- a/var/ramble/repos/builtin/applications/namd/application.py
+++ b/var/ramble/repos/builtin/applications/namd/application.py
@@ -13,7 +13,7 @@ from ramble.expander import Expander
 from ramble.keywords import keywords
 
 
-class Namd(SpackApplication):
+class Namd(ExecutableApplication):
     """Define NAMD application"""
 
     name = "namd"
@@ -34,7 +34,7 @@ class Namd(SpackApplication):
 
     software_spec("namd", pkg_spec="namd@2.14 interface=tcl", compiler="gcc12")
 
-    required_package("namd")
+    required_package("namd", package_manager="spack*")
 
     input_file(
         "stmv",

--- a/var/ramble/repos/builtin/applications/nvbandwidth/application.py
+++ b/var/ramble/repos/builtin/applications/nvbandwidth/application.py
@@ -9,7 +9,7 @@
 from ramble.appkit import *
 
 
-class Nvbandwidth(SpackApplication):
+class Nvbandwidth(ExecutableApplication):
     """Define the nvbandwidth benchmark"""
 
     name = "nvbandwidth"
@@ -20,7 +20,7 @@ class Nvbandwidth(SpackApplication):
 
     software_spec("nvbandwidth", pkg_spec="nvbandwidth")
 
-    required_package("nvbandwidth")
+    required_package("nvbandwidth", package_manager="spack*")
 
     workload("all_benchmarks", executable="nvbandwidth")
 

--- a/var/ramble/repos/builtin/applications/openfoam/application.py
+++ b/var/ramble/repos/builtin/applications/openfoam/application.py
@@ -20,7 +20,7 @@ class Openfoam(OpenfoamOrg):
 
     software_spec("openfoam", pkg_spec="openfoam@2312", compiler="gcc9")
 
-    required_package("openfoam")
+    required_package("openfoam", package_manager="spack*")
 
     executable(
         "surfaceFeatures",

--- a/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
+++ b/var/ramble/repos/builtin/applications/osu-micro-benchmarks/application.py
@@ -15,7 +15,7 @@ from ramble.expander import Expander
 from enum import Enum
 
 
-class OsuMicroBenchmarks(SpackApplication):
+class OsuMicroBenchmarks(ExecutableApplication):
     """Define an OSU micro benchmarks application"""
 
     name = "osu-micro-benchmarks"
@@ -30,7 +30,7 @@ class OsuMicroBenchmarks(SpackApplication):
         "osu-micro-benchmarks", pkg_spec="osu-micro-benchmarks", compiler="gcc"
     )
 
-    required_package("osu-micro-benchmarks")
+    required_package("osu-micro-benchmarks", package_manager="spack*")
 
     all_workloads = [
         "osu_bibw",

--- a/var/ramble/repos/builtin/applications/quantum-espresso/application.py
+++ b/var/ramble/repos/builtin/applications/quantum-espresso/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class QuantumEspresso(SpackApplication):
+class QuantumEspresso(ExecutableApplication):
     """Define Quantum-Espresso application."""
 
     name = "quantum-espresso"
@@ -34,7 +34,7 @@ class QuantumEspresso(SpackApplication):
         "quantum-espresso", pkg_spec="quantum-espresso@7.1", compiler="gcc13"
     )
 
-    required_package("quantum-espresso")
+    required_package("quantum-espresso", package_manager="spack*")
 
     input_file(
         "AUSURF112",

--- a/var/ramble/repos/builtin/applications/spack-stack/application.py
+++ b/var/ramble/repos/builtin/applications/spack-stack/application.py
@@ -12,7 +12,7 @@ from ramble.appkit import *
 import spack.util.executable
 
 
-class SpackStack(SpackApplication):
+class SpackStack(ExecutableApplication):
     """Application definition for creating a spack software stack
 
     This application definition is used solely to create spack software stacks.

--- a/var/ramble/repos/builtin/applications/streamc/application.py
+++ b/var/ramble/repos/builtin/applications/streamc/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Streamc(SpackApplication):
+class Streamc(ExecutableApplication):
     """Define STREAMC application"""
 
     name = "streamc"
@@ -33,7 +33,7 @@ class Streamc(SpackApplication):
         compiler="gcc12",
     )
 
-    required_package("stream")
+    required_package("stream", package_manager="spack*")
 
     executable("execute_c", "stream_c.exe")
 

--- a/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
+++ b/var/ramble/repos/builtin/applications/ufs-weather-model/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class UfsWeatherModel(SpackApplication):
+class UfsWeatherModel(ExecutableApplication):
     """Define FV3 application via ufs-weather-model"""
 
     name = "ufs-weather-model"
@@ -33,7 +33,7 @@ class UfsWeatherModel(SpackApplication):
         compiler="gcc9",
     )
 
-    required_package("ufs-weather-model")
+    required_package("ufs-weather-model", package_manager="spack*")
 
     input_file(
         "simple_test_case",

--- a/var/ramble/repos/builtin/applications/wrfv3/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv3/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Wrfv3(SpackApplication):
+class Wrfv3(ExecutableApplication):
     """Define Wrf version 3 application"""
 
     name = "wrfv3"
@@ -30,7 +30,7 @@ class Wrfv3(SpackApplication):
         compiler="gcc8",
     )
 
-    required_package("wrf")
+    required_package("wrf", package_manager="spack*")
 
     input_file(
         "CONUS_2p5km",

--- a/var/ramble/repos/builtin/applications/wrfv4/application.py
+++ b/var/ramble/repos/builtin/applications/wrfv4/application.py
@@ -11,7 +11,7 @@ from ramble.appkit import *
 from ramble.expander import Expander
 
 
-class Wrfv4(SpackApplication):
+class Wrfv4(ExecutableApplication):
     """Define Wrf version 4 application"""
 
     name = "wrfv4"
@@ -32,7 +32,7 @@ class Wrfv4(SpackApplication):
         compiler="gcc9",
     )
 
-    required_package("wrf")
+    required_package("wrf", package_manager="spack*")
 
     input_file(
         "CONUS_2p5km",

--- a/var/ramble/repos/builtin/modifiers/conditional-psm3/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/conditional-psm3/modifier.py
@@ -39,7 +39,7 @@ class ConditionalPsm3(BasicModifier):
     executable_modifier("apply_psm3")
 
     required_variable("psm3_mpi")
-    required_package("intel-oneapi-mpi")
+    required_package("intel-oneapi-mpi", package_manager="spack*")
 
     modifier_variable(
         "apply_psm3_exec_regex",

--- a/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
+++ b/var/ramble/repos/builtin/modifiers/intel-aps/modifier.py
@@ -9,7 +9,7 @@
 from ramble.modkit import *  # noqa: F403
 
 
-class IntelAps(SpackModifier):
+class IntelAps(BasicModifier):
     """Define a modifier for Intel's Application Performance Snapshot
 
     Intel's Application Performance Snapshot (APS) is a high level profiler. It
@@ -43,7 +43,7 @@ class IntelAps(SpackModifier):
 
     software_spec("intel-oneapi-vtune", pkg_spec="intel-oneapi-vtune")
 
-    required_package("intel-oneapi-vtune")
+    required_package("intel-oneapi-vtune", package_manager="spack*")
 
     executable_modifier("aps_summary")
 


### PR DESCRIPTION
This merge deprecates the spack base classes (SpackApplication and SpackModifier) as the spack functionality is now encapsulated in a package manager class instead.