### PR TITLE
Add a package manager for environment-modules

### DIFF
--- a/lib/ramble/ramble/application.py
+++ b/lib/ramble/ramble/application.py
@@ -47,6 +47,7 @@ import ramble.util.stats
 import ramble.util.graph
 import ramble.util.class_attributes
 from ramble.util.logger import logger
+from ramble.util.sourcing import source_str
 
 from ramble.workspace import namespace
 
@@ -2066,7 +2067,10 @@ class ApplicationBase(object, metaclass=ApplicationMeta):
                     app_licenses = license_conf[self.name]
                     if app_licenses:
                         # Append logic to source file which contains the exports
-                        command.append(f". {{license_input_dir}}/{self.license_inc_name}")
+                        shell = ramble.config.get("config:shell")
+                        command.append(
+                            f"{source_str(shell)} {{license_input_dir}}/{self.license_inc_name}"
+                        )
 
         # Process environment variable actions
         for env_var_set in self._env_variable_sets:

--- a/lib/ramble/ramble/package_manager.py
+++ b/lib/ramble/ramble/package_manager.py
@@ -88,12 +88,16 @@ class PackageManagerBase(object, metaclass=PackageManagerMeta):
     def get_spec_str(self, pkg, all_pkgs, compiler):
         """Return a spec string for the given pkg
 
+        Can be overridden by individual package managers to provide a more
+        specific package spec string. Default is to just return the detected
+        package spec.
+
         Args:
             pkg (RenderedPackage): Reference to a rendered package
             all_pkgs (dict): All related packages
             compiler (boolean): True if this pkg is used as a compiler
         """
-        return ""
+        return pkg.spec
 
     def spec_prefix(self):
         """Return this package manager's spec prefix

--- a/lib/ramble/ramble/util/sourcing.py
+++ b/lib/ramble/ramble/util/sourcing.py
@@ -1,0 +1,24 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+_shell_source_map = {"sh": ".", "bash": ".", "fish": "source", "csh": "source", "bat": "."}
+
+
+def source_str(shell):
+    """Wrapper to return the `source` command for a given shell
+
+    Args:
+        shell (str): Name of shell to get the source command for
+
+    Returns:
+        (str): Source command for the requested shell.
+    """
+
+    if shell in _shell_source_map:
+        return _shell_source_map[shell]
+    return ""

--- a/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
@@ -13,6 +13,9 @@ import llnl.util.filesystem as fs
 
 import ramble.util.hashing
 
+import ramble.config
+from ramble.util.sourcing import source_str
+
 
 class EnvironmentModules(PackageManagerBase):
     """Definition for using environment-modules as a package manager
@@ -25,9 +28,6 @@ class EnvironmentModules(PackageManagerBase):
     name = "environment-modules"
 
     maintainers("douglasjacobsen")
-
-    def get_spec_str(self, pkg, all_pkgs, compiler):
-        return pkg.spec
 
     register_phase(
         "write_module_commands",
@@ -88,4 +88,5 @@ class EnvironmentModules(PackageManagerBase):
     register_builtin("module_load", required=True)
 
     def module_load(self):
-        return [" . {env_path}/module_loads"]
+        shell = ramble.config.get("config:shell")
+        return [f"{source_str(shell)} " + "{env_path}/module_loads"]

--- a/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
+++ b/var/ramble/repos/builtin/package_managers/environment-modules/package_manager.py
@@ -1,0 +1,91 @@
+# Copyright 2022-2024 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from ramble.pkgmankit import *  # noqa: F403
+
+import os
+import llnl.util.filesystem as fs
+
+import ramble.util.hashing
+
+
+class EnvironmentModules(PackageManagerBase):
+    """Definition for using environment-modules as a package manager
+
+    This definition allows experiments to use environment-modules to manage the
+    software used in an experiment. It assumes the `module` command will be in
+    the path of the experiment at execution time.
+    """
+
+    name = "environment-modules"
+
+    maintainers("douglasjacobsen")
+
+    def get_spec_str(self, pkg, all_pkgs, compiler):
+        return pkg.spec
+
+    register_phase(
+        "write_module_commands",
+        pipeline="setup",
+        run_before=["make_experiments"],
+    )
+
+    def populate_inventory(
+        self, workspace, force_compute=False, require_exist=False
+    ):
+        env_path = self.app_inst.expander.env_path
+
+        self.app_inst.hash_inventory["package_manager"].append(
+            {
+                "name": self.name,
+            }
+        )
+
+        env_hash = ramble.util.hashing.hash_file(
+            os.path.join(env_path, "module_loads")
+        )
+
+        self.app_inst.hash_inventory["software"].append(
+            {
+                "name": env_path.replace(workspace.root + os.path.sep, ""),
+                "digest": env_hash,
+            }
+        )
+
+    def _write_module_commands(self, workspace, app_inst=None):
+
+        app_context = self.app_inst.expander.expand_var_name(
+            self.keywords.env_name
+        )
+
+        require_env = self.environment_required()
+
+        software_envs = workspace.software_environments
+        software_env = software_envs.render_environment(
+            app_context, self.app_inst.expander, self, require=require_env
+        )
+
+        env_path = self.app_inst.expander.env_path
+
+        module_file_path = os.path.join(env_path, "module_loads")
+
+        fs.mkdirp(env_path)
+
+        module_file = open(module_file_path, "w+")
+
+        if software_env is not None:
+            for spec in software_envs.package_specs_for_environment(
+                software_env
+            ):
+                module_file.write(f"module load {spec}\n")
+        module_file.close()
+
+    register_builtin("module_load", required=True)
+
+    def module_load(self):
+        return [" . {env_path}/module_loads"]


### PR DESCRIPTION
This merge adds an environment-modules package manager, which allows the generated environment to use `module load` commands.