### PR TITLE
Update edit command to edit other object types

### DIFF
--- a/lib/ramble/ramble/cmd/list.py
+++ b/lib/ramble/ramble/cmd/list.py
@@ -13,8 +13,6 @@ description = "list and search available objects"
 section = "basic"
 level = "short"
 
-app_type = ramble.repository.ObjectTypes.applications
-
 
 def setup_parser(subparser):
     ramble.cmd.common.list.setup_list_parser(subparser)


### PR DESCRIPTION
This merge updates the edit command to be able to control which object types it edits, similarly to the list and info commands.