### PR TITLE
Update external_spack_env to be external_env

### DIFF
--- a/lib/ramble/docs/configuration_files.rst
+++ b/lib/ramble/docs/configuration_files.rst
@@ -497,7 +497,7 @@ environments created from those packages. Its format is as follows:
           [matrix:]
           [matrices:]
         <external_env_name>:
-          external_spack_env: 'name_or_path_to_spack_env'
+          external_env: 'name_or_path_to_spack_env'
 
 The packages dictionary houses ramble descriptions of software packages that
 can be used to construct environments with. A package is defined as software
@@ -570,9 +570,9 @@ This section shows how this feature can be used.
     software:
       environments:
         gromacs:
-          external_spack_env: name_or_path_to_spack_env
+          external_env: name_or_path_to_spack_env
 
-In the above example, the ``external_spack_env`` keyword refers an external
+In the above example, the ``external_env`` keyword refers an external
 Spack environment. This can be the name of a named Spack environment, or the
 path to a directory which contains a Spack environment. Ramble will copy the
 ``spack.yaml`` file from this environment, instead of generating its own.

--- a/lib/ramble/llnl/util/tty/__init__.py
+++ b/lib/ramble/llnl/util/tty/__init__.py
@@ -324,6 +324,7 @@ def get_yes_or_no(prompt, **kwargs):
     result = None
     while result is None:
         msg(prompt, newline=False)
+        ans = input().lower()
         if not ans:
             result = default_value
             if result is None:

--- a/lib/ramble/ramble/namespace.py
+++ b/lib/ramble/ramble/namespace.py
@@ -46,7 +46,7 @@ class namespace:
 
     # For software definitions
     software = "software"
-    external_env = "external_spack_env"
+    external_env = "external_env"
 
     # v2 configs
     packages = "packages"

--- a/lib/ramble/ramble/schema/software.py
+++ b/lib/ramble/ramble/schema/software.py
@@ -12,6 +12,10 @@
    :lines: 12-
 """  # noqa E501
 
+import ramble.namespace
+
+namespace = ramble.namespace.namespace()
+
 
 #: Properties for inclusion in other schemas
 properties = {
@@ -48,6 +52,10 @@ properties = {
                 "additionalProperties": {
                     "type": "object",
                     "properties": {
+                        namespace.external_env: {
+                            "type": "string",
+                            "default": None,
+                        },
                         "packages": {"type": "array", "items": {"type": "string"}, "default": []},
                     },
                     "additionalProperties": {"type": "string"},

--- a/lib/ramble/ramble/schema/spack.py
+++ b/lib/ramble/ramble/schema/spack.py
@@ -12,6 +12,10 @@
    :lines: 12-
 """  # noqa E501
 
+import ramble.namespace
+
+namespace = ramble.namespace.namespace()
+
 
 #: Properties for inclusion in other schemas
 properties = {
@@ -45,6 +49,10 @@ properties = {
                     "type": "object",
                     "properties": {
                         "external_spack_env": {
+                            "type": "string",
+                            "default": None,
+                        },
+                        namespace.external_env: {
                             "type": "string",
                             "default": None,
                         },
@@ -91,5 +99,15 @@ def update(data):
                 if key in data["packages"][pkg_name] and newkey not in data["packages"][pkg_name]:
                     changed = True
                     data["packages"][pkg_name][newkey] = data["packages"][pkg_name][key]
+                    del data["packages"][pkg_name][key]
+
+    if "environments" in data:
+        for env_name in data["environments"]:
+            if "external_spack_env" in data["environments"][env_name]:
+                changed = True
+                data["environments"][env_name][namespace.external_env] = data["environments"][
+                    env_name
+                ]["external_spack_env"]
+                del data["environments"][env_name]["external_spack_env"]
 
     return changed

--- a/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
+++ b/lib/ramble/ramble/test/end_to_end/dryrun_copies_external_env.py
@@ -56,7 +56,7 @@ ramble:
     packages: {{}}
     environments:
       wrfv4:
-        external_spack_env: {env_path}
+        external_env: {env_path}
 """
 
     setup_type = ramble.pipeline.pipelines.setup

--- a/lib/ramble/ramble/workspace/workspace.py
+++ b/lib/ramble/ramble/workspace/workspace.py
@@ -840,13 +840,6 @@ class Workspace(object):
 
             yield contents, experiment_context
 
-    def external_spack_env(self, env_name):
-        env_context = self.software_environments.get_env(env_name)
-
-        if namespace.external_env not in env_context:
-            return None
-        return env_context[namespace.external_env]
-
     def concretize(self):
         full_software_dict = self.get_software_dict()
 


### PR DESCRIPTION
This merge changes external_spack_env to be the more general external_env. Additionally, this updates the spack schema update method so it can make tihs edit.