### PR TITLE
Refactor Renderer to use generators for memory efficiency

### DIFF
--- a/lib/ramble/ramble/renderer.py
+++ b/lib/ramble/ramble/renderer.py
@@ -188,10 +188,8 @@ class Renderer:
                 for i, unexpanded_var in enumerate(group_def):
                     group_def[i] = expander.expand_var(unexpanded_var)
 
-        new_objects = []
         defined_zips = {}
         consumed_zips = set()
-        matrix_objects = []
 
         if ignore_used:
             # Add variables / zips in matrices to used variables
@@ -292,6 +290,11 @@ class Renderer:
                     cur_zip["vars"][var_name] = object_variables[var_name]
                     del object_variables[var_name]
 
+        matrix_vars = set()
+        matrix_vectors = []
+        matrix_variables = []
+        matrix_size = 1
+
         if matrices:
             """Matrix syntax is:
             matrix:
@@ -311,13 +314,10 @@ class Renderer:
 
             # Perform some error checking
             last_size = -1
-            matrix_vars = set()
-            matrix_vectors = []
-            matrix_variables = []
+
             for matrix in matrices:
                 matrix_size = 1
                 vectors = []
-                zips = []
                 variable_names = []
                 for var in matrix:
                     if var in matrix_vars:
@@ -349,6 +349,8 @@ class Renderer:
                         matrix_size = matrix_size * zip_len
                         vectors.append(idx_vector)
                         variable_names.append(var)
+
+                        consumed_zips.add(var)
                     else:
                         err_context = object_variables[render_group.context]
                         logger.die(
@@ -369,38 +371,12 @@ class Renderer:
                 matrix_vectors.append(vectors)
                 matrix_variables.append(variable_names)
 
-            # Create the empty initial dictionairies
-            matrix_objects = []
-            for _ in range(matrix_size):
-                matrix_objects.append({})
-
-            # Generate all of the obj var dicts
-            for names, vectors in zip(matrix_variables, matrix_vectors):
-                for obj_idx, entry in enumerate(itertools.product(*vectors)):
-                    for name_idx, name in enumerate(names):
-                        if name in defined_zips.keys():
-                            # Replace the zip name with the constituent variables
-                            for zip_var in defined_zips[name]["vars"]:
-                                matrix_objects[obj_idx][zip_var] = defined_zips[name]["vars"][
-                                    zip_var
-                                ][entry[name_idx]]
-
-                            # Consume the defined zip
-                            consumed_zips.add(name)
-                        else:
-                            matrix_objects[obj_idx][name] = entry[name_idx]
-
-        # Remove all consumed zips and return all remaining zipped variables
-        # back to real vector definitions
+        # Restore unconsumed zips to object_variables
         if defined_zips:
-            if consumed_zips:
-                for zip_group in consumed_zips:
-                    if zip_group in defined_zips:
-                        del defined_zips[zip_group]
-
-            for zip_name in defined_zips:
-                for var, val in defined_zips[zip_name]["vars"].items():
-                    object_variables[var] = val
+            for zip_group in defined_zips:
+                if zip_group not in consumed_zips:
+                    for var, val in defined_zips[zip_group]["vars"].items():
+                        object_variables[var] = val
 
         # After matrices have been processed, extract any remaining vector variables
         vector_vars = {}
@@ -429,33 +405,10 @@ class Renderer:
                     err_str += f"\tVariable {var} has length {len(val)}\n"
                 logger.die(err_str)
 
-            # Iterate over the vector length, and set the value in the
-            # object dict to the index value.
-            for i in range(0, max_vector_size):
-                obj_vars = {}
-                for var, val in vector_vars.items():
-                    if len(val) > i:
-                        obj_vars[var] = val[i]
-
-                if matrix_objects:
-                    for matrix_object in matrix_objects:
-                        for var, val in matrix_object.items():
-                            obj_vars[var] = val
-
-                        new_objects.append(obj_vars.copy())
-                else:
-                    new_objects.append(obj_vars.copy())
-
-        elif matrix_objects:
-            new_objects = matrix_objects
-        else:
-            # Ensure at least one object is rendered, if everything was a scalar
-            new_objects.append({})
-
+        # Helper to yield objects
         where_expander = ramble.expander.Expander(object_variables, None)
 
-        for obj in new_objects:
-            logger.debug(f"Rendering {render_group.object}:")
+        def yield_object(obj):
             for var, val in obj.items():
                 object_variables[var] = val
 
@@ -473,6 +426,72 @@ class Renderer:
                 if n_repeats > 0:
                     repeats.set_repeats(True, n_repeats)
                 yield object_variables.copy(), repeats
+
+        # Generate objects
+        if vector_vars:
+            # Iterate over the vector length
+            for i in range(0, max_vector_size):
+                obj_vars = {}
+                for var, val in vector_vars.items():
+                    if len(val) > i:
+                        obj_vars[var] = val[i]
+
+                if matrix_vectors:
+                     # Generate matrix objects on the fly
+                     # We need to recreate iterators each time because we consume them
+                     # for each vector index `i`.
+
+                    matrix_products = []
+                    for vectors in matrix_vectors:
+                        matrix_products.append(itertools.product(*vectors))
+
+                    for products in zip(*matrix_products):
+                        # products is a tuple of tuples, one from each matrix
+                        merged_obj = {}
+                        for matrix_idx, values in enumerate(products):
+                            names = matrix_variables[matrix_idx]
+                            for name_idx, name in enumerate(names):
+                                 if name in defined_zips.keys():
+                                    for zip_var in defined_zips[name]["vars"]:
+                                        merged_obj[zip_var] = defined_zips[name]["vars"][
+                                            zip_var
+                                        ][values[name_idx]]
+                                 else:
+                                    merged_obj[name] = values[name_idx]
+
+                        current_obj = obj_vars.copy()
+                        current_obj.update(merged_obj)
+                        yield from yield_object(current_obj)
+
+                else:
+                    yield from yield_object(obj_vars)
+
+        elif matrix_vectors:
+             # Just matrices, no vector vars to cross with
+             # No loop over `i`, just once.
+
+            matrix_products = []
+            for vectors in matrix_vectors:
+                matrix_products.append(itertools.product(*vectors))
+
+            for products in zip(*matrix_products):
+                merged_obj = {}
+                for matrix_idx, values in enumerate(products):
+                    names = matrix_variables[matrix_idx]
+                    for name_idx, name in enumerate(names):
+                         if name in defined_zips.keys():
+                            for zip_var in defined_zips[name]["vars"]:
+                                merged_obj[zip_var] = defined_zips[name]["vars"][
+                                    zip_var
+                                ][values[name_idx]]
+                         else:
+                            merged_obj[name] = values[name_idx]
+
+                yield from yield_object(merged_obj)
+
+        else:
+            # Ensure at least one object is rendered, if everything was a scalar
+            yield from yield_object({})
 
 
 class RambleRendererError(ramble.error.RambleError):

--- a/lib/ramble/ramble/test/renderer.py
+++ b/lib/ramble/ramble/test/renderer.py
@@ -1,0 +1,142 @@
+# Copyright 2022-2026 The Ramble Authors
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import pytest
+import ramble.renderer
+
+def test_renderer_vector_expansion():
+    renderer = ramble.renderer.Renderer()
+    rg = ramble.renderer.RenderGroup("experiment", "create")
+    rg.variables = {
+        "var1": ["1", "2", "3", "4"],
+        "var2": ["a", "b", "c", "d"]
+    }
+    # No matrix, just vectors. Should zip them.
+    # Count should be max length = 4.
+    # We must set ignore_used=False to force expansion of variables not used in templates (since we have no templates here)
+
+    results = list(renderer.render_objects(rg, ignore_used=False))
+    assert len(results) == 4
+
+    # Check content
+    assert results[0][0]["var1"] == "1"
+    assert results[0][0]["var2"] == "a"
+    assert results[3][0]["var1"] == "4"
+    assert results[3][0]["var2"] == "d"
+
+def test_renderer_matrix_expansion():
+    renderer = ramble.renderer.Renderer()
+    rg = ramble.renderer.RenderGroup("experiment", "create")
+    rg.variables = {
+        "var1": ["1", "2"],
+        "var2": ["a", "b", "c"]
+    }
+    rg.matrices = [["var1", "var2"]]
+
+    # Matrix of 2 * 3 = 6
+    # Matrix variables are automatically considered "used"
+    results = list(renderer.render_objects(rg))
+    assert len(results) == 6
+
+    # Check uniqueness
+    experiments = set()
+    for res, _ in results:
+        experiments.add((res["var1"], res["var2"]))
+    assert len(experiments) == 6
+    assert ("1", "a") in experiments
+    assert ("2", "c") in experiments
+
+def test_renderer_multiple_matrices():
+    renderer = ramble.renderer.Renderer()
+    rg = ramble.renderer.RenderGroup("experiment", "create")
+    rg.variables = {
+        "var1": ["1", "2"],
+        "var2": ["a", "b"],
+        "var3": ["x", "y"],
+        "var4": ["foo", "bar"]
+    }
+    # Two matrices, must have same size.
+    # Matrix 1: var1 * var2 = 2 * 2 = 4 elements
+    # Matrix 2: var3 * var4 = 2 * 2 = 4 elements
+    rg.matrices = [["var1", "var2"], ["var3", "var4"]]
+
+    results = list(renderer.render_objects(rg))
+    assert len(results) == 4
+
+    # It should zip the results of the two matrices.
+    # Matrix 1 order: (1,a), (1,b), (2,a), (2,b)
+    # Matrix 2 order: (x,foo), (x,bar), (y,foo), (y,bar)
+    # Result 0: 1, a, x, foo
+
+    assert results[0][0]["var1"] == "1"
+    assert results[0][0]["var3"] == "x"
+    assert results[3][0]["var1"] == "2"
+    assert results[3][0]["var2"] == "b"
+    assert results[3][0]["var3"] == "y"
+    assert results[3][0]["var4"] == "bar"
+
+def test_renderer_matrix_and_vector():
+    renderer = ramble.renderer.Renderer()
+    rg = ramble.renderer.RenderGroup("experiment", "create")
+    rg.variables = {
+        "var1": ["1", "2"], # Matrix var
+        "var2": ["a", "b"], # Matrix var
+        "vec1": ["v1", "v2", "v3"] # Vector var
+    }
+    rg.matrices = [["var1", "var2"]]
+
+    # Matrix size: 2 * 2 = 4
+    # Vector size: 3
+    # Total: Cross Product of (Vector Indices) X (Matrix Objects)
+    # Vector size 3. Matrix size 4. Total = 12.
+    # Must use ignore_used=False for vec1 to be expanded.
+
+    results = list(renderer.render_objects(rg, ignore_used=False))
+    assert len(results) == 12
+
+def test_renderer_zip_in_matrix():
+    renderer = ramble.renderer.Renderer()
+    rg = ramble.renderer.RenderGroup("experiment", "create")
+    rg.variables = {
+        "var1": ["1", "2", "3"],
+        "var2": ["a", "b", "c"],
+        "var3": ["x", "y"]
+    }
+    rg.zips = {
+        "zip1": ["var1", "var2"]
+    }
+    # Zip length is 3.
+    # Matrix: zip1 * var3 = 3 * 2 = 6.
+    rg.matrices = [["zip1", "var3"]]
+
+    results = list(renderer.render_objects(rg))
+    assert len(results) == 6
+
+    # Check values
+    # var1 and var2 should move in lockstep
+    for res, _ in results:
+        idx = int(res["var1"]) - 1
+        assert res["var2"] == rg.variables["var2"][idx]
+
+def test_large_matrix_count():
+    # Performance/Scale test
+    renderer = ramble.renderer.Renderer()
+    rg = ramble.renderer.RenderGroup("experiment", "create")
+    size = 10
+    rg.variables = {
+        "d1": [str(i) for i in range(size)],
+        "d2": [str(i) for i in range(size)],
+        "d3": [str(i) for i in range(size)],
+    }
+    rg.matrices = [["d1", "d2", "d3"]]
+
+    # 10 * 10 * 10 = 1000
+    count = 0
+    for _ in renderer.render_objects(rg):
+        count += 1
+    assert count == 1000


### PR DESCRIPTION
Refactor `lib/ramble/ramble/renderer.py` to use generators instead of building a large list of objects in memory. This significantly reduces memory usage for large experiment sets generated via matrices or vector variables.

Key changes:
- `Renderer.render_objects` now yields results lazily.
- Removed intermediate `new_objects` and `matrix_objects` lists.
- Logic for combining vectors and matrices is now handled inside nested loops/generators.
- Matrix products are re-generated on demand when crossed with vector variables to keep memory usage low (CPU trade-off acceptable for memory scalability).

---
*PR created automatically by Jules for task [15263915809535101634](https://jules.google.com/task/15263915809535101634) started by @douglasjacobsen*